### PR TITLE
CI: trigger build only when PR is created

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,16 +6,8 @@
 # Name of this Workflow
 name: Build PineTime Firmware
 
-# When to run this Workflow...
-on:
-
-  # Run this Workflow when files are updated (Pushed) in the "master" Branch
-  push:
-    branches: [ master ]
-
-  # Also run this Workflow when a Pull Request is created or updated in the "master" Branch
-  pull_request:
-    branches: [ master ]
+# Run this Workflow when Pull Request is created or updated
+on: [pull_request]
 
 # Steps to run for the Workflow
 jobs:


### PR DESCRIPTION
Issue: #107 

I changed the workflow file to build firmware when PR created or commits in it updated.
I think there is no need to build every commit. Let's pity Github's servers =)