### PR TITLE
Use GitHub Pages for Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,36 +43,14 @@ As of now, here is the list of achievements of this project:
  - **[Experimental]** Bootloader based on [MCUBoot](https://juullabs-oss.github.io/mcuboot/)
  
 ## Documentation
+[Documentation site](https://pfeerick.github.io/InfiniTime/): For information on how to use, build, and program InfiniTime.
 
-### Develop
- - [Generate the fonts and symbols](src/displayapp/fonts/Readme.md)
-
-### Build, flash and debug
- - [Project branches](doc/branches.md)
- - [Versioning](doc/versioning.md)
- - [Files included in the release notes](doc/filesInReleaseNotes.md)
- - [Build the project](doc/buildAndProgram.md)
- - [Flash the firmware using OpenOCD and STLinkV2](doc/openOCD.md)
- - [Build the project with Docker](doc/buildWithDocker.md)
- - [Bootloader, OTA and DFU](./bootloader/README.md)
- - [Stub using NRF52-DK](./doc/PinetimeStubWithNrf52DK.md)
- - Logging with JLink RTT.
- - Using files from the releases
-
-### Contribute
- - [How to contribute ?](doc/contribute.md)
-
-### API
- - [BLE implementation and API](./doc/ble.md)
- 
-### Architecture and technical topics
- - [Memory analysis](./doc/MemoryAnalysis.md)
- 
-### Using the firmware
- - [Integration with Gadgetbridge](doc/companionapps/Gadgetbridge.md)
- - [Integration with AmazFish](doc/companionapps/Amazfish.md)
- - [Firmware update, OTA](doc/companionapps/NrfconnectOTA.md)
- 
+## Support
+There are various social media platforms and forums where you can get support for your PineTime/InfiniTime. The Discord #pinetime channel, Telegram group and Matrix group are all bridged together, so you can use the platform of your choice. 
+- [Discord chat](https://discordapp.com/invite/DgB7kzr) - Has a dedicated #pinetime channel
+- [Telegram group](https://t.me/pinetime)
+- [Matrix group](https://matrix.to/#/!MTPtVeaNjlLKdzMKWH:matrix.org?via=matrix.org&via=privacytools.io&via=feneas.org)
+- [pine64 forum](https://forum.pine64.org/forumdisplay.php?fid=135) - General support forum for the pine64 PineTime device
     
 ## TODO - contribute
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/index.md
+++ b/index.md
@@ -1,8 +1,12 @@
+# Develop
+- [Generate the fonts and symbols](src/displayapp/fonts/Readme.md)
+
 # Building and Programming
 - [Build and Program (natively)](doc/buildAndProgram.md)
 - [Build with Docker](doc/buildWithDocker.md)
 - [Programming with openOCD](doc/openOCD.md)
-- [Generate the fonts and symbols](src/displayapp/fonts/Readme.md)
+- Logging with JLink RTT
+- Using files from the releases
 
 # Project structure
 - [Branches](doc/branches.md)
@@ -11,11 +15,15 @@
 - [Developing using the NRF52DK](doc/PinetimeStubWithNrf52DK.md)
 - [How to Contribute](doc/contribute.md)
 
-# Reference
+# API
 - [BLE Implementation](doc/ble.md)
+
+# Reference
 - [Bootloader, OTA and DFU](bootloader/README.md)
+- [Memory Analysis](doc/MemoryAnalysis.md)
+- [SPI LCD Driver](doc/SPI-LCD-driver.md)
+
+# Using the firmware
 - [Integration with Gadgetbridge](doc/companionapps/Gadgetbridge.md)
 - [Integration with AmazFish](doc/companionapps/Amazfish.md)
 - [Firmware update, OTA](doc/companionapps/NrfconnectOTA.md)
-- [Memory Analysis](doc/MemoryAnalysis.md)
-- [SPI LCD Driver](doc/SPI-LCD-driver.md)

--- a/index.md
+++ b/index.md
@@ -1,0 +1,21 @@
+# Building and Programming
+- [Build and Program (natively)](doc/buildAndProgram.md)
+- [Build with Docker](doc/buildWithDocker.md)
+- [Programming with openOCD](doc/openOCD.md)
+- [Generate the fonts and symbols](src/displayapp/fonts/Readme.md)
+
+# Project structure
+- [Branches](doc/branches.md)
+- [Files in the release notes](doc/filesInReleaseNotes.md)
+- [Versioning](doc/versioning.md)
+- [Developing using the NRF52DK](doc/PinetimeStubWithNrf52DK.md)
+- [How to Contribute](doc/contribute.md)
+
+# Reference
+- [BLE Implementation](doc/ble.md)
+- [Bootloader, OTA and DFU](bootloader/README.md)
+- [Integration with Gadgetbridge](doc/companionapps/Gadgetbridge.md)
+- [Integration with AmazFish](doc/companionapps/Amazfish.md)
+- [Firmware update, OTA](doc/companionapps/NrfconnectOTA.md)
+- [Memory Analysis](doc/MemoryAnalysis.md)
+- [SPI LCD Driver](doc/SPI-LCD-driver.md)


### PR DESCRIPTION
Was playing around with gh-pages support, and thought I'd see if this is worth pursuing further. 

Basically the documentation 'site' is generated from all the markdown docs already existing, and it is just a matter of (in your case) specifying the `develop` branch and `/ (root)` as the GitHub Pages source (under the repo settings) for this to be used if merged. 

*i.e.*
![image](https://user-images.githubusercontent.com/5500713/99523537-ecf8ad00-29e2-11eb-92a7-573013f0ee3a.png)

https://pfeerick.github.io/InfiniTime/

Obviously the last change will be change the url... although it would probably be a good idea to rename the repo before that happens (if that is going to happen), as I don't believe gh-page urls redirect if the source repo moves... when I renamed a repo in the past github redirected properly... gh-pages just wants to be different. 

If you like this approach, I'll continue further reading through the documentation as I spotted some other typos or formatting glitches... otherwise, I'll start again, and just fix up the docs as they are... 
