### PR TITLE
Moved private statics into unnamed namespace in cpp file 

### DIFF
--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -15,6 +15,45 @@
 
 using namespace Pinetime::Applications::Screens;
 
+namespace {
+
+char const *DaysString[] = {
+        "",
+        "MONDAY",
+        "TUESDAY",
+        "WEDNESDAY",
+        "THURSDAY",
+        "FRIDAY",
+        "SATURDAY",
+        "SUNDAY"
+};
+
+char const *MonthsString[] = {
+        "",
+        "JAN",
+        "FEB",
+        "MAR",
+        "APR",
+        "MAY",
+        "JUN",
+        "JUL",
+        "AUG",
+        "SEP",
+        "OCT",
+        "NOV",
+        "DEC"
+};
+
+const char *MonthToString(Pinetime::Controllers::DateTime::Months month) {
+  return MonthsString[static_cast<uint8_t>(month)];
+}
+
+const char *DayOfWeekToString(Pinetime::Controllers::DateTime::Days dayOfWeek) {
+  return DaysString[static_cast<uint8_t>(dayOfWeek)];
+}
+
+}
+
 static void event_handler(lv_obj_t * obj, lv_event_t event) {
   Clock* screen = static_cast<Clock *>(obj->user_data);
   screen->OnObjectEvent(obj, event);
@@ -200,40 +239,6 @@ bool Clock::Refresh() {
   return running;
 }
 
-const char *Clock::MonthToString(Pinetime::Controllers::DateTime::Months month) {
-  return Clock::MonthsString[static_cast<uint8_t>(month)];
-}
-
-const char *Clock::DayOfWeekToString(Pinetime::Controllers::DateTime::Days dayOfWeek) {
-  return Clock::DaysString[static_cast<uint8_t>(dayOfWeek)];
-}
-
-char const *Clock::DaysString[] = {
-        "",
-        "MONDAY",
-        "TUESDAY",
-        "WEDNESDAY",
-        "THURSDAY",
-        "FRIDAY",
-        "SATURDAY",
-        "SUNDAY"
-};
-
-char const *Clock::MonthsString[] = {
-        "",
-        "JAN",
-        "FEB",
-        "MAR",
-        "APR",
-        "MAY",
-        "JUN",
-        "JUL",
-        "AUG",
-        "SEP",
-        "OCT",
-        "NOV",
-        "DEC"
-};
 
 void Clock::OnObjectEvent(lv_obj_t *obj, lv_event_t event) {
   if(obj == backgroundLabel) {

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -52,11 +52,6 @@ namespace Pinetime {
 
           void OnObjectEvent(lv_obj_t *pObj, lv_event_t i);
         private:
-          static const char* MonthToString(Pinetime::Controllers::DateTime::Months month);
-          static const char* DayOfWeekToString(Pinetime::Controllers::DateTime::Days dayOfWeek);
-          static char const *DaysString[];
-          static char const *MonthsString[];
-
           char displayedChar[5];
 
           uint16_t currentYear = 1970;


### PR DESCRIPTION
The Clock.h had unnecessary private static functions and members. These should not appear in a header file as they increase couple and add complexity to understanding of the header.

These have been moved to an unnamed namespace in Clock.cpp to aim readability and maintenace.
 
