### PR TITLE
Refactor Clock to use `lv_label_set_text_fmt` and other minor updates

### DIFF
--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -17,62 +17,30 @@ using namespace Pinetime::Applications::Screens;
 
 namespace {
 
-char const *DaysString[] = {
-        "",
-        "MONDAY",
-        "TUESDAY",
-        "WEDNESDAY",
-        "THURSDAY",
-        "FRIDAY",
-        "SATURDAY",
-        "SUNDAY"
-};
+  char const* const DaysString[] = {"", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"};
 
-char const *MonthsString[] = {
-        "",
-        "JAN",
-        "FEB",
-        "MAR",
-        "APR",
-        "MAY",
-        "JUN",
-        "JUL",
-        "AUG",
-        "SEP",
-        "OCT",
-        "NOV",
-        "DEC"
-};
+  char const* const MonthsString[] = {"", "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
 
-const char *MonthToString(Pinetime::Controllers::DateTime::Months month) {
-  return MonthsString[static_cast<uint8_t>(month)];
-}
+  const char* MonthToString(Pinetime::Controllers::DateTime::Months month) {
+    return MonthsString[static_cast<uint8_t>(month)];
+  }
 
-const char *DayOfWeekToString(Pinetime::Controllers::DateTime::Days dayOfWeek) {
-  return DaysString[static_cast<uint8_t>(dayOfWeek)];
-}
+  const char* DayOfWeekToString(Pinetime::Controllers::DateTime::Days dayOfWeek) {
+    return DaysString[static_cast<uint8_t>(dayOfWeek)];
+  }
 
 }
 
-static void event_handler(lv_obj_t * obj, lv_event_t event) {
-  Clock* screen = static_cast<Clock *>(obj->user_data);
+static void event_handler(lv_obj_t* obj, lv_event_t event) {
+  Clock* screen = static_cast<Clock*>(obj->user_data);
   screen->OnObjectEvent(obj, event);
 }
 
-Clock::Clock(DisplayApp* app,
-        Controllers::DateTime& dateTimeController,
-        Controllers::Battery& batteryController,
-        Controllers::Ble& bleController,
-        Controllers::NotificationManager& notificatioManager,
-        Controllers::HeartRateController& heartRateController): Screen(app), currentDateTime{{}},
-                                           dateTimeController{dateTimeController}, batteryController{batteryController},
-                                           bleController{bleController}, notificatioManager{notificatioManager},
-                                           heartRateController{heartRateController} {
-  displayedChar[0] = 0;
-  displayedChar[1] = 0;
-  displayedChar[2] = 0;
-  displayedChar[3] = 0;
-  displayedChar[4] = 0;
+Clock::Clock(DisplayApp* app, Controllers::DateTime& dateTimeController, Controllers::Battery& batteryController,
+             Controllers::Ble& bleController, Controllers::NotificationManager& notificatioManager,
+             Controllers::HeartRateController& heartRateController)
+  : Screen {app}, dateTimeController {dateTimeController}, batteryController {batteryController},
+    bleController {bleController}, notificatioManager {notificatioManager}, heartRateController {heartRateController} {
 
   batteryIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text(batteryIcon, Symbols::batteryFull);
@@ -86,7 +54,7 @@ Clock::Clock(DisplayApp* app,
   lv_label_set_text(bleIcon, Symbols::bluetooth);
   lv_obj_align(bleIcon, batteryPlug, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 
-  notificationIcon = lv_label_create(lv_scr_act(), NULL);
+  notificationIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(false));
   lv_obj_align(notificationIcon, nullptr, LV_ALIGN_IN_TOP_LEFT, 10, 0);
 
@@ -108,7 +76,6 @@ Clock::Clock(DisplayApp* app,
   lv_obj_set_size(backgroundLabel, 240, 240);
   lv_obj_set_pos(backgroundLabel, 0, 0);
   lv_label_set_text(backgroundLabel, "");
-
 
   heartbeatIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text(heartbeatIcon, Symbols::heartBeat);
@@ -146,35 +113,30 @@ bool Clock::Refresh() {
 
   bleState = bleController.IsConnected();
   if (bleState.IsUpdated()) {
-    if(bleState.Get() == true) {
-      lv_label_set_text(bleIcon, BleIcon::GetIcon(true));
-    } else {
-      lv_label_set_text(bleIcon, BleIcon::GetIcon(false));
-    }
+    lv_label_set_text(bleIcon, BleIcon::GetIcon(bleState.Get())); // return true/fasle
   }
   lv_obj_align(batteryIcon, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, -5, 5);
   lv_obj_align(batteryPlug, batteryIcon, LV_ALIGN_OUT_LEFT_MID, -5, 0);
   lv_obj_align(bleIcon, batteryPlug, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 
   notificationState = notificatioManager.AreNewNotificationsAvailable();
-  if(notificationState.IsUpdated()) {
-    if(notificationState.Get() == true)
+  if (notificationState.IsUpdated()) {
+    if (notificationState.Get() == true)
       lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(true));
     else
       lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(false));
   }
 
   currentDateTime = dateTimeController.CurrentDateTime();
-
-  if(currentDateTime.IsUpdated()) {
+  if (currentDateTime.IsUpdated()) {
     auto newDateTime = currentDateTime.Get();
 
     auto dp = date::floor<date::days>(newDateTime);
-    auto time = date::make_time(newDateTime-dp);
+    auto time = date::make_time(newDateTime - dp);
     auto yearMonthDay = date::year_month_day(dp);
 
     auto year = static_cast<int>(yearMonthDay.year());
-    auto month = static_cast<Pinetime::Controllers::DateTime::Months>((unsigned)yearMonthDay.month());
+    auto month = static_cast<Pinetime::Controllers::DateTime::Months>((unsigned) yearMonthDay.month());
     auto day = static_cast<unsigned>(yearMonthDay.day());
     auto dayOfWeek = static_cast<Pinetime::Controllers::DateTime::Days>(date::weekday(yearMonthDay).iso_encoding());
 
@@ -187,17 +149,18 @@ bool Clock::Refresh() {
     char hoursChar[3];
     sprintf(hoursChar, "%02d", static_cast<int>(hour));
 
-    if((hoursChar[0] != displayedChar[0]) or (hoursChar[1] != displayedChar[1]) or (minutesChar[0] != displayedChar[2]) or (minutesChar[1] != displayedChar[3])) {
+    if ((hoursChar[0] != displayedChar[0]) or (hoursChar[1] != displayedChar[1]) or (minutesChar[0] != displayedChar[2]) or
+        (minutesChar[1] != displayedChar[3])) {
       displayedChar[0] = hoursChar[0];
       displayedChar[1] = hoursChar[1];
       displayedChar[2] = minutesChar[0];
       displayedChar[3] = minutesChar[1];
 
-      lv_label_set_text_fmt(label_time,"%s:%s", hoursChar,minutesChar);
+      lv_label_set_text_fmt(label_time, "%s:%s", hoursChar, minutesChar);
     }
 
     if ((year != currentYear) or (month != currentMonth) or (dayOfWeek != currentDayOfWeek) or (day != currentDay)) {
-      lv_label_set_text_fmt(label_date,"%s %d %s %d", DayOfWeekToString(dayOfWeek), day, MonthToString(month), year);
+      lv_label_set_text_fmt(label_date, "%s %d %s %d", DayOfWeekToString(dayOfWeek), day, MonthToString(month), year);
 
       currentYear = year;
       currentMonth = month;
@@ -208,24 +171,21 @@ bool Clock::Refresh() {
 
   heartbeat = heartRateController.HeartRate();
   heartbeatRunning = heartRateController.State() != Controllers::HeartRateController::States::Stopped;
-  if(heartbeat.IsUpdated() or heartbeatRunning.IsUpdated()) {
-    char heartbeatBuffer[4];
-    if(heartbeatRunning.Get())
-      sprintf(heartbeatBuffer, "%d", heartbeat.Get());
-    else
-      sprintf(heartbeatBuffer, "---");
+  if (heartbeat.IsUpdated() or heartbeatRunning.IsUpdated()) {
+    if (heartbeatRunning.Get()) {
+      lv_label_set_text_fmt(heartbeatValue, "%d", heartbeat.Get());
+    } else {
+      lv_label_set_text(heartbeatValue, "---");
+    }
 
-    lv_label_set_text(heartbeatValue, heartbeatBuffer);
     lv_obj_align(heartbeatIcon, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 5, -2);
     lv_obj_align(heartbeatValue, heartbeatIcon, LV_ALIGN_OUT_RIGHT_MID, 5, 0);
     lv_obj_align(heartbeatBpm, heartbeatValue, LV_ALIGN_OUT_RIGHT_MID, 5, 0);
   }
 
   // TODO stepCount = stepController.GetValue();
-  if(stepCount.IsUpdated()) {
-    char stepBuffer[5];
-    sprintf(stepBuffer, "%lu", stepCount.Get());
-    lv_label_set_text(stepValue, stepBuffer);
+  if (stepCount.IsUpdated()) {
+    lv_label_set_text_fmt(stepValue, "%lu", stepCount.Get());
     lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, -5, -2);
     lv_obj_align(stepIcon, stepValue, LV_ALIGN_OUT_LEFT_MID, -5, 0);
   }
@@ -233,11 +193,9 @@ bool Clock::Refresh() {
   return running;
 }
 
-
-void Clock::OnObjectEvent(lv_obj_t *obj, lv_event_t event) {
-  if(obj == backgroundLabel) {
+void Clock::OnObjectEvent(lv_obj_t* obj, lv_event_t event) {
+  if (obj == backgroundLabel) {
     if (event == LV_EVENT_CLICKED) {
-
       running = false;
     }
   }
@@ -247,5 +205,3 @@ bool Clock::OnButtonPushed() {
   running = false;
   return false;
 }
-
-

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -140,7 +140,7 @@ bool Clock::Refresh() {
   if (batteryPercentRemaining.IsUpdated()) {
     auto batteryPercent = batteryPercentRemaining.Get();
     lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
-    auto isCharging = batteryController.IsCharging() || batteryController.IsPowerPresent();
+    auto isCharging = batteryController.IsCharging() or batteryController.IsPowerPresent();
     lv_label_set_text(batteryPlug, BatteryIcon::GetPlugIcon(isCharging));
   }
 
@@ -173,9 +173,9 @@ bool Clock::Refresh() {
     auto time = date::make_time(newDateTime-dp);
     auto yearMonthDay = date::year_month_day(dp);
 
-    auto year = (int)yearMonthDay.year();
+    auto year = static_cast<int>(yearMonthDay.year());
     auto month = static_cast<Pinetime::Controllers::DateTime::Months>((unsigned)yearMonthDay.month());
-    auto day = (unsigned)yearMonthDay.day();
+    auto day = static_cast<unsigned>(yearMonthDay.day());
     auto dayOfWeek = static_cast<Pinetime::Controllers::DateTime::Days>(date::weekday(yearMonthDay).iso_encoding());
 
     auto hour = time.hours().count();
@@ -187,23 +187,17 @@ bool Clock::Refresh() {
     char hoursChar[3];
     sprintf(hoursChar, "%02d", static_cast<int>(hour));
 
-    char timeStr[6];
-    sprintf(timeStr, "%c%c:%c%c", hoursChar[0],hoursChar[1],minutesChar[0], minutesChar[1]);
-
-    if(hoursChar[0] != displayedChar[0] || hoursChar[1] != displayedChar[1] || minutesChar[0] != displayedChar[2] || minutesChar[1] != displayedChar[3]) {
+    if((hoursChar[0] != displayedChar[0]) or (hoursChar[1] != displayedChar[1]) or (minutesChar[0] != displayedChar[2]) or (minutesChar[1] != displayedChar[3])) {
       displayedChar[0] = hoursChar[0];
       displayedChar[1] = hoursChar[1];
       displayedChar[2] = minutesChar[0];
       displayedChar[3] = minutesChar[1];
 
-      lv_label_set_text(label_time, timeStr);
+      lv_label_set_text_fmt(label_time,"%s:%s", hoursChar,minutesChar);
     }
 
-    if ((year != currentYear) || (month != currentMonth) || (dayOfWeek != currentDayOfWeek) || (day != currentDay)) {
-      char dateStr[22];
-      sprintf(dateStr, "%s %d %s %d", DayOfWeekToString(dayOfWeek), day, MonthToString(month), year);
-      lv_label_set_text(label_date, dateStr);
-
+    if ((year != currentYear) or (month != currentMonth) or (dayOfWeek != currentDayOfWeek) or (day != currentDay)) {
+      lv_label_set_text_fmt(label_date,"%s %d %s %d", DayOfWeekToString(dayOfWeek), day, MonthToString(month), year);
 
       currentYear = year;
       currentMonth = month;
@@ -214,7 +208,7 @@ bool Clock::Refresh() {
 
   heartbeat = heartRateController.HeartRate();
   heartbeatRunning = heartRateController.State() != Controllers::HeartRateController::States::Stopped;
-  if(heartbeat.IsUpdated() || heartbeatRunning.IsUpdated()) {
+  if(heartbeat.IsUpdated() or heartbeatRunning.IsUpdated()) {
     char heartbeatBuffer[4];
     if(heartbeatRunning.Get())
       sprintf(heartbeatBuffer, "%d", heartbeat.Get());

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -18,76 +18,79 @@ namespace Pinetime {
   namespace Applications {
     namespace Screens {
 
-      template <class T>
-      class DirtyValue {
-        public:
-          DirtyValue() = default;                      // Use NSDMI
-          explicit DirtyValue(T const& v):value{v}{}   // Use MIL and const-lvalue-ref
-          bool IsUpdated() const { return isUpdated; }
-          T const& Get() { this->isUpdated = false; return value; }  // never expose a non-const lvalue-ref
-          DirtyValue& operator=(const T& other) {
-            if (this->value != other) {
-              this->value = other;
-              this->isUpdated = true;
-            }
-            return *this;
+      template <class T> class DirtyValue {
+      public:
+        DirtyValue() = default; // Use NSDMI
+        explicit DirtyValue(T const& v) : value {v} {
+        } // Use MIL and const-lvalue-ref
+        bool IsUpdated() const {
+          return isUpdated;
+        }
+        T const& Get() {
+          this->isUpdated = false;
+          return value;
+        } // never expose a non-const lvalue-ref
+        DirtyValue& operator=(const T& other) {
+          if (this->value != other) {
+            this->value = other;
+            this->isUpdated = true;
           }
-        private:
-          T value{};            // NSDMI - default initialise type
-          bool isUpdated{true}; // NSDMI - use brace initilisation
+          return *this;
+        }
+
+      private:
+        T value {};            // NSDMI - default initialise type
+        bool isUpdated {true}; // NSDMI - use brace initilisation
       };
 
       class Clock : public Screen {
-        public:
-          Clock(DisplayApp* app,
-                  Controllers::DateTime& dateTimeController,
-                  Controllers::Battery& batteryController,
-                  Controllers::Ble& bleController,
-                  Controllers::NotificationManager& notificatioManager,
-                  Controllers::HeartRateController& heartRateController);
-          ~Clock() override;
+      public:
+        Clock(DisplayApp* app, Controllers::DateTime& dateTimeController, Controllers::Battery& batteryController,
+              Controllers::Ble& bleController, Controllers::NotificationManager& notificatioManager,
+              Controllers::HeartRateController& heartRateController);
+        ~Clock() override;
 
-          bool Refresh() override;
-          bool OnButtonPushed() override;
+        bool Refresh() override;
+        bool OnButtonPushed() override;
 
-          void OnObjectEvent(lv_obj_t *pObj, lv_event_t i);
-        private:
-          char displayedChar[5];
+        void OnObjectEvent(lv_obj_t* pObj, lv_event_t i);
 
-          uint16_t currentYear = 1970;
-          Pinetime::Controllers::DateTime::Months currentMonth = Pinetime::Controllers::DateTime::Months::Unknown;
-          Pinetime::Controllers::DateTime::Days currentDayOfWeek = Pinetime::Controllers::DateTime::Days::Unknown;
-          uint8_t currentDay = 0;
+      private:
+        char displayedChar[5] {}; // NSDMI will zero all values
 
-          DirtyValue<int> batteryPercentRemaining  {};
-          DirtyValue<bool> bleState {};
-          DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime{};
-          DirtyValue<uint32_t> stepCount  {};
-          DirtyValue<uint8_t> heartbeat  {};
-          DirtyValue<bool> heartbeatRunning  {};
-          DirtyValue<bool> notificationState {};
+        uint16_t currentYear = 1970;
+        Pinetime::Controllers::DateTime::Months currentMonth = Pinetime::Controllers::DateTime::Months::Unknown;
+        Pinetime::Controllers::DateTime::Days currentDayOfWeek = Pinetime::Controllers::DateTime::Days::Unknown;
+        uint8_t currentDay = 0;
 
-          lv_obj_t* label_time;
-          lv_obj_t* label_date;
-          lv_obj_t* backgroundLabel;
-          lv_obj_t* batteryIcon;
-          lv_obj_t* bleIcon;
-          lv_obj_t* batteryPlug;
-          lv_obj_t* heartbeatIcon;
-          lv_obj_t* heartbeatValue;
-          lv_obj_t* heartbeatBpm;
-          lv_obj_t* stepIcon;
-          lv_obj_t* stepValue;
-          lv_obj_t* notificationIcon;
+        DirtyValue<int> batteryPercentRemaining {};
+        DirtyValue<bool> bleState {};
+        DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime {};
+        DirtyValue<uint32_t> stepCount {};
+        DirtyValue<uint8_t> heartbeat {};
+        DirtyValue<bool> heartbeatRunning {};
+        DirtyValue<bool> notificationState {};
 
-          Controllers::DateTime& dateTimeController;
-          Controllers::Battery& batteryController;
-          Controllers::Ble& bleController;
-          Controllers::NotificationManager& notificatioManager;
-          Controllers::HeartRateController& heartRateController;
+        lv_obj_t* label_time {}; // NSDMI will ensure nullptr
+        lv_obj_t* label_date {};
+        lv_obj_t* backgroundLabel {};
+        lv_obj_t* batteryIcon {};
+        lv_obj_t* bleIcon {};
+        lv_obj_t* batteryPlug {};
+        lv_obj_t* heartbeatIcon {};
+        lv_obj_t* heartbeatValue {};
+        lv_obj_t* heartbeatBpm {};
+        lv_obj_t* stepIcon {};
+        lv_obj_t* stepValue {};
+        lv_obj_t* notificationIcon {};
 
-          bool running = true;
+        Controllers::DateTime& dateTimeController;
+        Controllers::Battery& batteryController;
+        Controllers::Ble& bleController;
+        Controllers::NotificationManager& notificatioManager;
+        Controllers::HeartRateController& heartRateController;
 
+        bool running = true;
       };
     }
   }


### PR DESCRIPTION
Minor refactoring of Clock.h/.cpp

1. Replaced unnecessary `sprintf` statements with the build-in `lvgl` `lv_label_set_text_fmt` function (designed for that exact purpose)
2. Cleaned up Clock construction and member-initialisation list, where the NSDMI can be used in preference (e.g. defaults zero values and `nullptr`)
3. Cleaned up some logic code
4. Change some instances of `||` to `or` (this is a C++ keyword, as is `and` and `not` and has been since the original C++98 standard)
5. Ran Clock.* through clang-tidy based on `.clang-format` file at project root
6. Replaced any remaining NULL with nullptr
7. Replaced C-style casts with C++ casts