### PR TITLE
WIP : Add support for notification title

### DIFF
--- a/src/components/ble/AlertNotificationClient.cpp
+++ b/src/components/ble/AlertNotificationClient.cpp
@@ -165,6 +165,7 @@ void AlertNotificationClient::OnNotification(ble_gap_event *event) {
     NotificationManager::Notification notif;
     os_mbuf_copydata(event->notify_rx.om, headerSize, messageSize - 1, notif.message.data());
     notif.message[messageSize - 1] = '\0';
+    notif.size = messageSize;
     notif.category = Pinetime::Controllers::NotificationManager::Categories::SimpleAlert;
     notificationManager.Push(std::move(notif));
 

--- a/src/components/ble/AlertNotificationClient.cpp
+++ b/src/components/ble/AlertNotificationClient.cpp
@@ -158,8 +158,11 @@ void AlertNotificationClient::OnNotification(ble_gap_event *event) {
     const auto maxMessageSize{NotificationManager::MaximumMessageSize()};
     const auto maxBufferSize{maxMessageSize + headerSize};
 
-    const auto dbgPacketLen = OS_MBUF_PKTLEN(event->notify_rx.om);
-    size_t bufferSize = std::min(dbgPacketLen + stringTerminatorSize, maxBufferSize);
+    // Ignore notifications with empty message
+    const auto packetLen = OS_MBUF_PKTLEN(event->notify_rx.om);
+    if(packetLen <= headerSize) return;
+
+    size_t bufferSize = std::min(packetLen + stringTerminatorSize, maxBufferSize);
     auto messageSize = std::min(maxMessageSize, (bufferSize - headerSize));
 
     NotificationManager::Notification notif;

--- a/src/components/ble/AlertNotificationService.cpp
+++ b/src/components/ble/AlertNotificationService.cpp
@@ -75,6 +75,7 @@ int AlertNotificationService::OnAlert(uint16_t conn_handle, uint16_t attr_handle
     os_mbuf_copydata(ctxt->om, headerSize, messageSize-1, notif.message.data());
     os_mbuf_copydata(ctxt->om, 0, 1, &category);
     notif.message[messageSize-1] = '\0';
+    notif.size = messageSize;
 
     // TODO convert all ANS categories to NotificationController categories
     switch(category) {

--- a/src/components/ble/AlertNotificationService.cpp
+++ b/src/components/ble/AlertNotificationService.cpp
@@ -66,8 +66,11 @@ int AlertNotificationService::OnAlert(uint16_t conn_handle, uint16_t attr_handle
     const auto maxMessageSize {NotificationManager::MaximumMessageSize()};
     const auto maxBufferSize{maxMessageSize + headerSize};
 
-    const auto dbgPacketLen = OS_MBUF_PKTLEN(ctxt->om);
-    size_t bufferSize = std::min(dbgPacketLen + stringTerminatorSize, maxBufferSize);
+    // Ignore notifications with empty message
+    const auto packetLen = OS_MBUF_PKTLEN(ctxt->om);
+    if(packetLen <= headerSize) return 0;
+
+    size_t bufferSize = std::min(packetLen + stringTerminatorSize, maxBufferSize);
     auto messageSize = std::min(maxMessageSize, (bufferSize-headerSize));
     Categories category;
 

--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -191,7 +191,6 @@ int Pinetime::Controllers::MusicService::OnCommand(uint16_t conn_handle, uint16_
     data[notifSize] = '\0';
     os_mbuf_copydata(ctxt->om, 0, notifSize, data);
     char *s = (char *) &data[0];
-    NRF_LOG_INFO("DATA : %s", s);
     if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t *) &msArtistCharUuid) == 0) {
       artistName = s;
     } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t *) &msTrackCharUuid) == 0) {

--- a/src/components/ble/NavigationService.cpp
+++ b/src/components/ble/NavigationService.cpp
@@ -101,7 +101,6 @@ int Pinetime::Controllers::NavigationService::OnCommand(uint16_t conn_handle, ui
     data[notifSize] = '\0';
     os_mbuf_copydata(ctxt->om, 0, notifSize, data);
     char *s = (char *) &data[0];
-    NRF_LOG_INFO("DATA : %s", s);
     if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t *) &navFlagCharUuid) == 0) {
       m_flag = s;
     } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t *) &navNarrativeCharUuid) == 0) {

--- a/src/components/ble/NotificationManager.cpp
+++ b/src/components/ble/NotificationManager.cpp
@@ -87,3 +87,19 @@ size_t NotificationManager::NbNotifications() const {
   return std::count_if(notifications.begin(), notifications.end(), [](const Notification& n){ return n.valid;});
 }
 
+const char* NotificationManager::Notification::Message() const {
+  const char* itField = std::find(message.begin(), message.begin()+size-1, '\0');
+  if(itField != message.begin()+size-1) {
+    const char* ptr = (itField)+1;
+    return ptr;
+  }
+  return const_cast<char*>(message.data());
+}
+
+const char* NotificationManager::Notification::Title() const {
+  const char * itField = std::find(message.begin(), message.begin()+size-1, '\0');
+  if(itField != message.begin()+size-1) {
+    return message.data();
+  }
+  return {};
+}

--- a/src/components/ble/NotificationManager.h
+++ b/src/components/ble/NotificationManager.h
@@ -17,8 +17,12 @@ namespace Pinetime {
           Id id;
           bool valid = false;
           uint8_t index;
+          uint8_t size;
           std::array<char, MessageSize+1> message;
           Categories category = Categories::Unknown;
+
+          const char* Message() const;
+          const char* Title() const;
         };
         Notification::Id nextId {0};
 

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -17,8 +17,8 @@ Notifications::Notifications(DisplayApp *app,
   auto notification = notificationManager.GetLastNotification();
   if(notification.valid) {
     currentId = notification.id;
-    currentItem = std::make_unique<NotificationItem>("\nNotification",
-                                           notification.message.data(),
+    currentItem = std::make_unique<NotificationItem>(notification.Title(),
+                                           notification.Message(),
                                            notification.index,
                                            notification.category,
                                            notificationManager.NbNotifications(),
@@ -87,8 +87,8 @@ bool Notifications::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
       currentId = previousNotification.id;
       currentItem.reset(nullptr);
       app->SetFullRefresh(DisplayApp::FullRefreshDirections::Up);
-      currentItem = std::make_unique<NotificationItem>("\nNotification",
-                                             previousNotification.message.data(),
+      currentItem = std::make_unique<NotificationItem>(previousNotification.Title(),
+                                             previousNotification.Message(),
                                              previousNotification.index,
                                              previousNotification.category,
                                              notificationManager.NbNotifications(),
@@ -109,8 +109,8 @@ bool Notifications::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
       currentId = nextNotification.id;
       currentItem.reset(nullptr);
       app->SetFullRefresh(DisplayApp::FullRefreshDirections::Down);
-      currentItem = std::make_unique<NotificationItem>("\nNotification",
-                                             nextNotification.message.data(),
+      currentItem = std::make_unique<NotificationItem>(nextNotification.Title(),
+                                             nextNotification.Message(),
                                              nextNotification.index,
                                              nextNotification.category,
                                              notificationManager.NbNotifications(),
@@ -178,8 +178,9 @@ namespace {
 
   lv_obj_t* alert_type = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(alert_type, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x888888));
+  if(title == nullptr) title = "Notification";
   lv_label_set_text(alert_type, title);
-  lv_obj_align(alert_type, NULL, LV_ALIGN_IN_TOP_LEFT, 0, -4);
+  lv_obj_align(alert_type, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 16);
 
   /////////
   switch(category) {

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -73,6 +73,8 @@ bool Notifications::Refresh() {
 }
 
 bool Notifications::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
+  if(mode != Modes::Normal) return true;
+
   switch (event) {
     case Pinetime::Applications::TouchEvents::SwipeUp: {
       Controllers::NotificationManager::Notification previousNotification;


### PR DESCRIPTION
Add support for notification title. The notification buffer must contain the title and the message separated by a '\0' character.

If the buffer does not contain any \0, the whole buffer is considered to be the message of the notification. A default title will be displayed in the notification app.

Already tested with Amazfish:
![infinitime-spotify](https://user-images.githubusercontent.com/2261652/113506552-d5f7c900-9545-11eb-8ddc-40c1df6015f0.jpg)

- [x] Wait for feedbacks from Gadgetbridge