### PR TITLE
Fix music app

### DIFF
--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -164,7 +164,7 @@ Pinetime::Controllers::MusicService::MusicService(Pinetime::System::SystemTask &
   
   artistName = "Waiting for";
   albumName = "";
-  trackName = "track information...";
+  trackName = "track information..";
   playing = false;
   repeat = false;
   shuffle = false;

--- a/src/displayapp/screens/Music.cpp
+++ b/src/displayapp/screens/Music.cpp
@@ -98,24 +98,28 @@ Music::Music(Pinetime::Applications::DisplayApp *app, Pinetime::Controllers::Mus
   lv_label_set_text(txtTrackDuration, "--:--/--:--");
   lv_label_set_align(txtTrackDuration, LV_ALIGN_IN_LEFT_MID);
   lv_obj_set_width(txtTrackDuration, LV_HOR_RES);
-  
+
   constexpr uint8_t FONT_HEIGHT = 12;
   constexpr uint8_t LINE_PAD = 15;
   constexpr int8_t MIDDLE_OFFSET = -25;
   txtArtist = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_long_mode(txtArtist, LV_LABEL_LONG_SROLL);
+  lv_label_set_long_mode(txtArtist, LV_LABEL_LONG_SROLL_CIRC);
+  lv_label_set_anim_speed(txtArtist, 1);
   lv_obj_align(txtArtist, nullptr, LV_ALIGN_IN_LEFT_MID, 12, MIDDLE_OFFSET + 1 * FONT_HEIGHT);
-  lv_label_set_text(txtArtist, "Artist Name");
   lv_label_set_align(txtArtist, LV_ALIGN_IN_LEFT_MID);
-  lv_obj_set_width(txtArtist, LV_HOR_RES);
-  
+  lv_obj_set_width(txtArtist, LV_HOR_RES-12);
+  lv_label_set_text(txtArtist, "Artist Name");
+
+
   txtTrack = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_long_mode(txtTrack, LV_LABEL_LONG_SROLL);
+  lv_label_set_long_mode(txtTrack, LV_LABEL_LONG_SROLL_CIRC);
+  lv_label_set_anim_speed(txtTrack, 1);
   lv_obj_align(txtTrack, nullptr, LV_ALIGN_IN_LEFT_MID, 12, MIDDLE_OFFSET + 2 * FONT_HEIGHT + LINE_PAD);
-  lv_label_set_text(txtTrack, "This is a very long getTrack name");
+
   lv_label_set_align(txtTrack, LV_ALIGN_IN_LEFT_MID);
-  lv_obj_set_width(txtTrack, LV_HOR_RES);
-  
+  lv_obj_set_width(txtTrack, LV_HOR_RES-12);
+  lv_label_set_text(txtTrack, "This is a very long getTrack name");
+
   /** Init animation */
   imgDisc = lv_img_create(lv_scr_act(), nullptr);
   lv_img_set_src_arr(imgDisc, &disc);

--- a/src/displayapp/screens/Music.h
+++ b/src/displayapp/screens/Music.h
@@ -76,7 +76,7 @@ namespace Pinetime {
         /** Last length */
         int lastLength;
         /** Last time an animation update or timer was incremented */
-        TickType_t lastIncrement;
+        TickType_t lastIncrement = 0;
         
         bool playing;
         

--- a/src/libs/lv_conf.h
+++ b/src/libs/lv_conf.h
@@ -140,7 +140,7 @@ typedef int16_t lv_coord_t;
  *==================*/
 
 /*1: Enable the Animations */
-#define LV_USE_ANIMATION        0
+#define LV_USE_ANIMATION        1
 #if LV_USE_ANIMATION
 
 /*Declare the type of the user data of animations (can be e.g. `void *`, `int`, `struct`)*/
@@ -177,7 +177,7 @@ typedef void* lv_anim_user_data_t;
 #define LV_USE_IMG_TRANSFORM    0
 
 /* 1: Enable object groups (for keyboard/encoder navigation) */
-#define LV_USE_GROUP            1
+#define LV_USE_GROUP            0
 #if LV_USE_GROUP
 typedef void* lv_group_user_data_t;
 #endif  /*LV_USE_GROUP*/


### PR DESCRIPTION
 - Enable LVGL animation (and disable groups, which were not used), and set the speed.
 - Fix disc animation and progress display by initializing lastIncrement at 0 (a random value will be used otherwise, in release build)

Fix #97  and #130 