### PR TITLE
Removed 'Waiting for track information...' from music player

### DIFF
--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -161,10 +161,10 @@ Pinetime::Controllers::MusicService::MusicService(Pinetime::System::SystemTask &
       .characteristics = characteristicDefinition
   };
   serviceDefinition[1] = {0};
-  
-  artistName = "Waiting for";
+
+  artistName = "";
   albumName = "";
-  trackName = "track information..";
+  trackName = "";
   playing = false;
   repeat = false;
   shuffle = false;


### PR DESCRIPTION
Not sure if this should be combined with another visual indicator, but most music players (e.g. VLC) really don't include anything when nothing's playing, and the text feels excessively technical and/or confusing for average users. I'm sure that everyone else can discern whether Gadgetbridge or another companion app is managing to send notification data properly, even without any output. The text is also too long and gets cut off from the screen.