### PR TITLE
bin2c: Don't assume that the default Python version is higher than 2

### DIFF
--- a/tools/bin2c.py
+++ b/tools/bin2c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #-*- coding: utf-8 -*-
 """
     bin2c


### PR DESCRIPTION
Continuation of the failed #280