### PR TITLE
Gitpod workspace path update due to repo rename

### DIFF
--- a/docker/.gitpod.Dockerfile
+++ b/docker/.gitpod.Dockerfile
@@ -14,15 +14,16 @@ RUN apt-get update -qq \
       python3-pip \
       tar \
       unzip \
-      wget \ 
+      wget \
 # aarch64 packages
       libffi-dev \
       libssl-dev \
-      python3-dev \ 
+      python3-dev \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/*;
 
 # Needs to be installed as root
 RUN pip3 install adafruit-nrfutil
+RUN pip3 install -Iv cryptography==3.3
 
 COPY docker/build.sh /opt/
 # Lets get each in a separate docker layer for better downloads
@@ -34,6 +35,6 @@ RUN bash -c "source /opt/build.sh; GetNrfSdk;"
 RUN bash -c "source /opt/build.sh; GetMcuBoot;"
 
 # Link the default checkout workspace in to the default $SOURCES_DIR
-RUN ln -s /workspace/Pinetime /sources
+RUN ln -s /workspace/InfiniTime /sources
 
 USER gitpod


### PR DESCRIPTION
Gitpod workspace path is based on repo name... it was `/workspace/Pinetime`, 
but after the repo rename it's now `/workspace/InfiniTime`. 
Also added second pip call as it's in the main dockerfile.