### PR TITLE
Added Python virtual environment to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .idea/
+# Python virtual environment for DFU images
+.venv/
+
 # CMake
 cmake-build-*
 cmake-*


### PR DESCRIPTION
It's a good practice to create a virtual environment for different projects that require Python.

This PR adds the most common Python virtual environment path to .gitignore.