### PR TITLE
Added a pre-commit hook that should simplify commiting pre-formatted code

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,5 @@
+# Git hooks
+
+This directory contains Git hooks that simplify contributing to this repository.
+
+You can install them by copying the files into `.git/hooks` in the repository folder or by running `git config --local core.hooksPath hooks`

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,13 +1,19 @@
 #!/bin/bash
+if clang-format --version | grep -q 'version 11\.'; then
+   CLANG_FORMAT_EXECUTABLE="clang-format"
+else
+   CLANG_FORMAT_EXECUTABLE="clang-format-11"
+fi
+
 for FILE in $(git diff --cached --name-only)
 do
 	if [[ "$FILE" =~ src/[A-Za-z0-9\ \-]+*\.(c|h|cpp|cc)$ ]]; then
-		echo Autoformatting $FILE with clang-format
-		clang-format-11 -style=file -i -- $FILE
+		echo Autoformatting $FILE with $CLANG_FORMAT_EXECUTABLE
+		$CLANG_FORMAT_EXECUTABLE -style=file -i -- $FILE
 		git add -- $FILE
 	elif [[ "$FILE" =~ src/(components|displayapp|drivers|heartratetask|logging|systemtask)/.*\.(c|h|cpp|cc)$ ]]; then
-		echo Autoformatting $FILE with clang-format
-		clang-format-11 -style=file -i -- $FILE
+		echo Autoformatting $FILE with $CLANG_FORMAT_EXECUTABLE
+		$CLANG_FORMAT_EXECUTABLE -style=file -i -- $FILE
 		git add -- $FILE
 	fi
 done

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/bash
+for FILE in $(git diff --cached --name-only)
+do
+	if [[ "$FILE" =~ src/[A-Za-z0-9\ \-]+*\.(c|h|cpp|cc)$ ]]; then
+		echo Autoformatting $FILE with clang-format
+		clang-format-11 -style=file -i -- $FILE
+		git add -- $FILE
+	elif [[ "$FILE" =~ src/(components|displayapp|drivers|heartratetask|logging|systemtask)/.*\.(c|h|cpp|cc)$ ]]; then
+		echo Autoformatting $FILE with clang-format
+		clang-format-11 -style=file -i -- $FILE
+		git add -- $FILE
+	fi
+done

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,6 +5,12 @@ else
    CLANG_FORMAT_EXECUTABLE="clang-format-11"
 fi
 
+if ! command -v $CLANG_FORMAT_EXECUTABLE &> /dev/null
+then
+    echo $CLANG_FORMAT_EXECUTABLE does not exist, make sure to install it
+    exit 1
+fi
+
 for FILE in $(git diff --cached --name-only)
 do
 	if [[ "$FILE" =~ src/[A-Za-z0-9\ \-]+*\.(c|h|cpp|cc)$ ]]; then


### PR DESCRIPTION
In order to reduce forgetfulness when commiting code it's a good idea to have a pre-commit hook. This also creates the opportunity of creating a PR gate that checks that it is enabled.

This PR adds a simple pre-commit hook that autoformats files that are in a known safe location, that's why the relatively ugly regex. Just in case it also prints out that it is doing so. I also included a README in the folder with installation instructions.