### PR TITLE
Short vibration when enabling it in quick settings menu

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -7,6 +7,7 @@
 #include "components/datetime/DateTimeController.h"
 #include "components/ble/NotificationManager.h"
 #include "components/motion/MotionController.h"
+#include "components/motor/MotorController.h"
 #include "displayapp/screens/ApplicationList.h"
 #include "displayapp/screens/Brightness.h"
 #include "displayapp/screens/Clock.h"
@@ -51,6 +52,7 @@ DisplayApp::DisplayApp(Drivers::St7789& lcd,
                        Pinetime::Controllers::NotificationManager& notificationManager,
                        Pinetime::Controllers::HeartRateController& heartRateController,
                        Controllers::Settings& settingsController,
+                       Pinetime::Controllers::MotorController& motorController,
                        Pinetime::Controllers::MotionController& motionController)
   : lcd {lcd},
     lvgl {lvgl},
@@ -63,6 +65,7 @@ DisplayApp::DisplayApp(Drivers::St7789& lcd,
     notificationManager {notificationManager},
     heartRateController {heartRateController},
     settingsController {settingsController},
+    motorController{motorController},
     motionController {motionController} {
   msgQueue = xQueueCreate(queueSize, itemSize);
   // Start clock when smartwatch boots
@@ -262,7 +265,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
     // Settings
     case Apps::QuickSettings:
       currentScreen =
-        std::make_unique<Screens::QuickSettings>(this, batteryController, dateTimeController, brightnessController, settingsController);
+        std::make_unique<Screens::QuickSettings>(this, batteryController, dateTimeController, brightnessController, motorController, settingsController);
       returnApp(Apps::Clock, FullRefreshDirections::LeftAnim, TouchEvents::SwipeLeft);
       break;
     case Apps::Settings:

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -8,6 +8,7 @@
 #include "LittleVgl.h"
 #include "TouchEvents.h"
 #include "components/brightness/BrightnessController.h"
+#include "components/motor/MotorController.h"
 #include "components/firmwarevalidator/FirmwareValidator.h"
 #include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
@@ -51,6 +52,7 @@ namespace Pinetime {
                  Pinetime::Controllers::NotificationManager& notificationManager,
                  Pinetime::Controllers::HeartRateController& heartRateController,
                  Controllers::Settings& settingsController,
+                 Pinetime::Controllers::MotorController& motorController,
                  Pinetime::Controllers::MotionController& motionController);
       void Start();
       void PushMessage(Display::Messages msg);
@@ -72,6 +74,7 @@ namespace Pinetime {
       Pinetime::Controllers::NotificationManager& notificationManager;
       Pinetime::Controllers::HeartRateController& heartRateController;
       Pinetime::Controllers::Settings& settingsController;
+      Pinetime::Controllers::MotorController& motorController;
       Pinetime::Controllers::MotionController& motionController;
 
       Pinetime::Controllers::FirmwareValidator validator;

--- a/src/displayapp/DisplayAppRecovery.cpp
+++ b/src/displayapp/DisplayAppRecovery.cpp
@@ -18,6 +18,7 @@ DisplayApp::DisplayApp(Drivers::St7789& lcd,
                        Pinetime::Controllers::NotificationManager& notificationManager,
                        Pinetime::Controllers::HeartRateController& heartRateController,
                        Pinetime::Controllers::Settings& settingsController,
+                       Pinetime::Controllers::MotorController& motorController,
                        Pinetime::Controllers::MotionController& motionController)
   : lcd {lcd}, bleController {bleController} {
   msgQueue = xQueueCreate(queueSize, itemSize);

--- a/src/displayapp/DisplayAppRecovery.h
+++ b/src/displayapp/DisplayAppRecovery.h
@@ -17,6 +17,7 @@
 #include <drivers/Watchdog.h>
 #include <components/heartrate/HeartRateController.h>
 #include <components/motion/MotionController.h>
+#include <components/motor/MotorController.h>
 #include <components/settings/Settings.h>
 #include "TouchEvents.h"
 #include "Apps.h"
@@ -41,6 +42,7 @@ namespace Pinetime {
                  Pinetime::Controllers::NotificationManager& notificationManager,
                  Pinetime::Controllers::HeartRateController& heartRateController,
                  Pinetime::Controllers::Settings& settingsController,
+                 Pinetime::Controllers::MotorController& motorController,
                  Pinetime::Controllers::MotionController& motionController);
       void Start();
       void PushMessage(Pinetime::Applications::Display::Messages msg);

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -21,11 +21,13 @@ QuickSettings::QuickSettings(Pinetime::Applications::DisplayApp* app,
                              Pinetime::Controllers::Battery& batteryController,
                              Controllers::DateTime& dateTimeController,
                              Controllers::BrightnessController& brightness,
+                             Controllers::MotorController& motorController,
                              Pinetime::Controllers::Settings& settingsController)
   : Screen(app),
     batteryController {batteryController},
     dateTimeController {dateTimeController},
     brightness {brightness},
+    motorController{motorController},
     settingsController {settingsController} {
 
   // Time
@@ -138,6 +140,7 @@ void QuickSettings::OnButtonEvent(lv_obj_t* object, lv_event_t event) {
 
     if (lv_obj_get_state(btn3, LV_BTN_PART_MAIN) & LV_STATE_CHECKED) {
       settingsController.SetVibrationStatus(Controllers::Settings::Vibration::ON);
+      motorController.SetDuration(35);
       lv_label_set_text_static(btn3_lvl, Symbols::notificationsOn);
     } else {
       settingsController.SetVibrationStatus(Controllers::Settings::Vibration::OFF);

--- a/src/displayapp/screens/settings/QuickSettings.h
+++ b/src/displayapp/screens/settings/QuickSettings.h
@@ -7,6 +7,7 @@
 #include <lvgl/lvgl.h>
 #include "components/datetime/DateTimeController.h"
 #include "components/brightness/BrightnessController.h"
+#include "components/motor/MotorController.h"
 #include "components/settings/Settings.h"
 #include "components/battery/BatteryController.h"
 
@@ -21,6 +22,7 @@ namespace Pinetime {
                       Pinetime::Controllers::Battery& batteryController,
                       Controllers::DateTime& dateTimeController,
                       Controllers::BrightnessController& brightness,
+                      Controllers::MotorController& motorController,
                       Pinetime::Controllers::Settings& settingsController);
 
         ~QuickSettings() override;
@@ -36,6 +38,7 @@ namespace Pinetime {
         Pinetime::Controllers::Battery& batteryController;
         Controllers::DateTime& dateTimeController;
         Controllers::BrightnessController& brightness;
+        Controllers::MotorController& motorController;
         Controllers::Settings& settingsController;
 
         lv_task_t* taskUpdate;

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -115,6 +115,7 @@ void SystemTask::Work() {
                                                                     notificationManager,
                                                                     heartRateController,
                                                                     settingsController,
+                                                                    motorController,
                                                                     motionController);
   displayApp->Start();
 


### PR DESCRIPTION
Goal: Give a short vibration when vibrations are toggled on from the quick settings menu

Fix #271 

I don't have the battery connected to my devkit right now so I'm unable to test if the vibration is working. Perfect if anyone want to test it out for me. Otherwise this will have to wait until i receive my sealed devices.