### PR TITLE
SPI flash sleep if bootloader >= 1.0.0

### DIFF
--- a/src/BootloaderVersion.cpp
+++ b/src/BootloaderVersion.cpp
@@ -1,26 +1,36 @@
 #include <cstdint>
+#include <cstdio>
 #include "BootloaderVersion.h"
 
 using namespace Pinetime;
 
-// NOTE : current bootloader does not export its version to the application firmware.
+// NOTE : version < 1.0.0 of bootloader does not export its version to the application firmware.
 
-uint32_t BootloaderVersion::Major() {
-  return 0;
+uint32_t BootloaderVersion::version = 0;
+char BootloaderVersion::versionString[BootloaderVersion::VERSION_STR_LEN] = "0.0.0";
+
+const uint32_t BootloaderVersion::Major() {
+  return (BootloaderVersion::version >> 16u) & 0xff;
 }
 
-uint32_t BootloaderVersion::Minor() {
-  return 0;
+const uint32_t BootloaderVersion::Minor() {
+  return (BootloaderVersion::version >> 8u) & 0xff;
 }
 
-uint32_t BootloaderVersion::Patch() {
-  return 0;
+const uint32_t BootloaderVersion::Patch() {
+  return BootloaderVersion::version & 0xff;
 }
 
 const char* BootloaderVersion::VersionString() {
-  return "0.0.0";
+  return BootloaderVersion::versionString;
 }
 
-bool BootloaderVersion::IsValid() {
-  return false;
+const bool BootloaderVersion::IsValid() {
+  return BootloaderVersion::version >= 0x00010000;
+}
+
+void BootloaderVersion::SetVersion(uint32_t v) {
+  BootloaderVersion::version = v;
+  snprintf(BootloaderVersion::versionString, BootloaderVersion::VERSION_STR_LEN, "%ld.%ld.%ld",
+           BootloaderVersion::Major(), BootloaderVersion::Minor(), BootloaderVersion::Patch());
 }

--- a/src/BootloaderVersion.h
+++ b/src/BootloaderVersion.h
@@ -3,10 +3,15 @@
 namespace Pinetime {
   class BootloaderVersion {
   public:
-    static uint32_t Major();
-    static uint32_t Minor();
-    static uint32_t Patch();
+    static const uint32_t Major();
+    static const uint32_t Minor();
+    static const uint32_t Patch();
     static const char* VersionString();
-    static bool IsValid();
+    static const bool IsValid();
+    static void SetVersion(uint32_t v);
+  private:
+    static uint32_t version;
+    static constexpr size_t VERSION_STR_LEN = 12;
+    static char versionString[VERSION_STR_LEN];
   };
 }

--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -121,6 +121,11 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
       NRF_LOG_INFO(
         "[DFU] -> Start data received : SD size : %d, BT size : %d, app size : %d", softdeviceSize, bootloaderSize, applicationSize);
 
+      // wait until SystemTask has finished waking up all devices
+      while (systemTask.IsSleeping()) {
+        vTaskDelay(50); // 50ms
+      }
+
       dfuImage.Erase();
 
       uint8_t data[] {16, 1, 1};

--- a/src/displayapp/screens/SystemInfo.cpp
+++ b/src/displayapp/screens/SystemInfo.cpp
@@ -3,6 +3,7 @@
 #include "../DisplayApp.h"
 #include "Label.h"
 #include "Version.h"
+#include "BootloaderVersion.h"
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
 #include "components/brightness/BrightnessController.h"
@@ -83,17 +84,19 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen1() {
   lv_label_set_recolor(label, true);
   lv_label_set_text_fmt(label,
                         "#FFFF00 InfiniTime#\n\n"
-                        "#444444 Version# %ld.%ld.%ld\n\n"
-                        "#444444 Short Ref# %s\n\n"
+                        "#444444 Version# %ld.%ld.%ld\n"
+                        "#444444 Short Ref# %s\n"
                         "#444444 Build date#\n"
                         "%s\n"
-                        "%s\n",
+                        "%s\n\n"
+                        "#444444 Bootloader# %s",
                         Version::Major(),
                         Version::Minor(),
                         Version::Patch(),
                         Version::GitCommitHash(),
                         __DATE__,
-                        __TIME__);
+                        __TIME__,
+                        BootloaderVersion::VersionString());
   lv_label_set_align(label, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(label, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
   return std::make_unique<Screens::Label>(0, 5, app, label);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@
 #include <drivers/Hrs3300.h>
 #include <drivers/Bma421.h>
 
+#include "BootloaderVersion.h"
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
 #include "components/ble/NotificationManager.h"
@@ -305,6 +306,9 @@ int main(void) {
 
   debounceTimer = xTimerCreate("debounceTimer", 200, pdFALSE, (void*) 0, DebounceTimerCallback);
   debounceChargeTimer = xTimerCreate("debounceTimerCharge", 200, pdFALSE, (void*) 0, DebounceTimerChargeCallback);
+
+  // retrieve version stored by bootloader
+  Pinetime::BootloaderVersion::SetVersion(NRF_TIMER2->CC[0]);
 
   lvgl.Init();
 

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -73,6 +73,10 @@ namespace Pinetime {
         return nimbleController;
       };
 
+      bool IsSleeping() const {
+        return isSleeping;
+      }
+
     private:
       TaskHandle_t taskHandle;
 


### PR DESCRIPTION
This PR provide the following improvements:
- Extracts version exported by bootloader
- Displays bootloader version on System Info screen (Settings -> About menu)
- Enable SPI flash sleep mode if bootloader version >= 1.0.0

Unfortunately, I recently sealed my dev kit after flashing InfiniTime 1.0.0, so I would appreciate if someone with an open dev kit could help with the following tests:
- Is the reported bootloader version == 0.0.0 on watches with a bootloader older than 1.0.0 (before it exported its version in `NRF_TIMER2->CC[0]`)? Or is it a random value?
- Does this patch improve the power consumption of the watch when the screen is off? @vbelloir @nanch if any of you still have a setup to measure current in the μA range, I would love to have your feedback.

I'm also open to code improvement advice. I'm not a C++ developer so I'm not sure if storing the bootloader version in a class static variable is an acceptable way to do it or not.

Thanks a lot!