### PR TITLE
BugFix: Freeze `click` package (dependency of another package) version to 7.1.2 in *Dockerfile

### DIFF
--- a/docker/.gitpod.Dockerfile
+++ b/docker/.gitpod.Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update -qq \
 
 # Needs to be installed as root
 RUN pip3 install adafruit-nrfutil
-RUN pip3 install -Iv cryptography==3.3
+RUN pip3 install -Iv cryptography==3.3 click==7.1.2
 
 COPY docker/build.sh /opt/
 # Lets get each in a separate docker layer for better downloads

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -qq \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/*;
 
 RUN pip3 install adafruit-nrfutil
-RUN pip3 install -Iv cryptography==3.3
+RUN pip3 install -Iv cryptography==3.3 click==7.1.2
 
 # build.sh knows how to compile
 COPY build.sh /opt/


### PR DESCRIPTION
This fixes a build error caused by a newer version of the `click` package (for instance, 8.0.0)