### PR TITLE
Feature: Store and show git short ref on PineTime alongside other firmware information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,10 +55,22 @@ if(BUILD_DFU)
   set(BUILD_DFU true)
 endif()
 
+set(PROJECT_GIT_COMMIT_HASH "")
+
+execute_process(COMMAND git rev-parse --short HEAD
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                OUTPUT_VARIABLE PROJECT_GIT_COMMIT_HASH
+                RESULT_VARIABLE PROJECT_GIT_COMMIT_HASH_SUCCESS)
+
+string(STRIP ${PROJECT_GIT_COMMIT_HASH} PROJECT_GIT_COMMIT_HASH)
+
+message("PROJECT_GIT_COMMIT_HASH_SUCCESS? " ${PROJECT_GIT_COMMIT_HASH_SUCCESS})
+
 message("BUILD CONFIGURATION")
 message("-------------------")
 message("    * Version : " ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 message("    * Toolchain : " ${ARM_NONE_EABI_TOOLCHAIN_PATH})
+message("    * GitRef(S) : " ${PROJECT_GIT_COMMIT_HASH})
 message("    * NRF52 SDK : " ${NRF5_SDK_PATH})
 set(PROGRAMMER "???")
 if(USE_JLINK)

--- a/docker/.gitpod.Dockerfile
+++ b/docker/.gitpod.Dockerfile
@@ -19,7 +19,10 @@ RUN apt-get update -qq \
       libffi-dev \
       libssl-dev \
       python3-dev \
+      git \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/*;
+
+# Git needed for PROJECT_GIT_COMMIT_HASH variable setting
 
 # Needs to be installed as root
 RUN pip3 install adafruit-nrfutil

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,10 @@ RUN apt-get update -qq \
       libssl-dev \
       python3-dev \
       python \
+      git \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/*;
+
+# Git needed for PROJECT_GIT_COMMIT_HASH variable setting
 
 RUN pip3 install adafruit-nrfutil
 RUN pip3 install -Iv cryptography==3.3

--- a/src/Version.h.in
+++ b/src/Version.h.in
@@ -8,11 +8,13 @@ namespace Pinetime {
       static constexpr uint32_t Major() {return major;}
       static constexpr uint32_t Minor() {return minor;}
       static constexpr uint32_t Patch() {return patch;}
+      static constexpr const char* GitCommitHash() {return commitHash;}
       static constexpr const char* VersionString() {return versionString;}
     private:
       static constexpr uint32_t major = @PROJECT_VERSION_MAJOR@;
       static constexpr uint32_t minor = @PROJECT_VERSION_MINOR@;
       static constexpr uint32_t patch = @PROJECT_VERSION_PATCH@;
+      static constexpr const char* commitHash = "@PROJECT_GIT_COMMIT_HASH@";
       static constexpr const char* versionString = "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@";
   };
 }

--- a/src/displayapp/screens/FirmwareValidation.cpp
+++ b/src/displayapp/screens/FirmwareValidation.cpp
@@ -27,6 +27,17 @@ FirmwareValidation::FirmwareValidation(Pinetime::Applications::DisplayApp* app, 
   sprintf(version, "%ld.%ld.%ld", Version::Major(), Version::Minor(), Version::Patch());
   lv_label_set_text(labelVersionValue, version);
 
+  labelShortRefInfo = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_align(labelShortRefInfo, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 25);
+  lv_label_set_text(labelShortRefInfo, "ShortRef : ");
+  lv_label_set_align(labelShortRefInfo, LV_LABEL_ALIGN_LEFT);
+
+  labelShortRefValue = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_align(labelShortRefValue, labelShortRefInfo, LV_ALIGN_OUT_RIGHT_MID, 0, 0);
+  lv_label_set_recolor(labelShortRefValue, true);
+  sprintf(shortref, "%s", Version::GitCommitHash());
+  lv_label_set_text(labelShortRefValue, shortref);
+
   labelIsValidated = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_align(labelIsValidated, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 50);
   lv_label_set_recolor(labelIsValidated, true);

--- a/src/displayapp/screens/FirmwareValidation.h
+++ b/src/displayapp/screens/FirmwareValidation.h
@@ -25,7 +25,10 @@ namespace Pinetime {
 
         lv_obj_t* labelVersionInfo;
         lv_obj_t* labelVersionValue;
+        lv_obj_t* labelShortRefInfo;
+        lv_obj_t* labelShortRefValue;
         char version[9];
+        char shortref[9];
         lv_obj_t* labelIsValidated;
         lv_obj_t* buttonValidate;
         lv_obj_t* labelButtonValidate;

--- a/src/displayapp/screens/SystemInfo.cpp
+++ b/src/displayapp/screens/SystemInfo.cpp
@@ -69,12 +69,14 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen1() {
   lv_label_set_text_fmt(label,
                         "#FFFF00 InfiniTime#\n\n"
                         "#444444 Version# %ld.%ld.%ld\n\n"
+                        "#444444 Short Ref# %s\n\n"
                         "#444444 Build date#\n"
                         "%s\n"
                         "%s\n",
                         Version::Major(),
                         Version::Minor(),
                         Version::Patch(),
+                        Version::GitCommitHash(),
                         __DATE__,
                         __TIME__);
   lv_label_set_align(label, LV_LABEL_ALIGN_CENTER);


### PR DESCRIPTION
I think this feature would be useful for developers.
These three commits quite independent
 - first adds git package to docker image (for the people who use this build method)
 - second adds `git rev-parse --short HEAD => PROJECT_GIT_COMMIT_HASH` in CMakeLists.txt
 - and, finally, third adds the ability to show short ref on the SystemInfo app first screen and FirmwareValidation app screen