### PR TITLE
Fixed a naming inconsistency of DisplayApp::ReturnApp and a few formatting errors

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -65,7 +65,7 @@ DisplayApp::DisplayApp(Drivers::St7789& lcd,
     notificationManager {notificationManager},
     heartRateController {heartRateController},
     settingsController {settingsController},
-    motorController{motorController},
+    motorController {motorController},
     motionController {motionController} {
   msgQueue = xQueueCreate(queueSize, itemSize);
   // Start clock when smartwatch boots
@@ -213,7 +213,7 @@ void DisplayApp::StartApp(Apps app, DisplayApp::FullRefreshDirections direction)
   LoadApp(app, direction);
 }
 
-void DisplayApp::returnApp(Apps app, DisplayApp::FullRefreshDirections direction, TouchEvents touchEvent) {
+void DisplayApp::ReturnApp(Apps app, DisplayApp::FullRefreshDirections direction, TouchEvents touchEvent) {
   returnToApp = app;
   returnDirection = direction;
   returnTouchEvent = touchEvent;
@@ -224,12 +224,12 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
   SetFullRefresh(direction);
 
   // default return to launcher
-  returnApp(Apps::Launcher, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+  ReturnApp(Apps::Launcher, FullRefreshDirections::Down, TouchEvents::SwipeDown);
 
   switch (app) {
     case Apps::Launcher:
       currentScreen = std::make_unique<Screens::ApplicationList>(this, settingsController, batteryController, dateTimeController);
-      returnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      ReturnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::None:
     case Apps::Clock:
@@ -245,7 +245,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
 
     case Apps::FirmwareValidation:
       currentScreen = std::make_unique<Screens::FirmwareValidation>(this, validator);
-      returnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::FirmwareUpdate:
       currentScreen = std::make_unique<Screens::FirmwareUpdate>(this, bleController);
@@ -254,54 +254,54 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
     case Apps::Notifications:
       currentScreen = std::make_unique<Screens::Notifications>(
         this, notificationManager, systemTask.nimble().alertService(), Screens::Notifications::Modes::Normal);
-      returnApp(Apps::Clock, FullRefreshDirections::Up, TouchEvents::SwipeUp);
+      ReturnApp(Apps::Clock, FullRefreshDirections::Up, TouchEvents::SwipeUp);
       break;
     case Apps::NotificationsPreview:
       currentScreen = std::make_unique<Screens::Notifications>(
         this, notificationManager, systemTask.nimble().alertService(), Screens::Notifications::Modes::Preview);
-      returnApp(Apps::Clock, FullRefreshDirections::Up, TouchEvents::SwipeUp);
+      ReturnApp(Apps::Clock, FullRefreshDirections::Up, TouchEvents::SwipeUp);
       break;
 
     // Settings
     case Apps::QuickSettings:
-      currentScreen =
-        std::make_unique<Screens::QuickSettings>(this, batteryController, dateTimeController, brightnessController, motorController, settingsController);
-      returnApp(Apps::Clock, FullRefreshDirections::LeftAnim, TouchEvents::SwipeLeft);
+      currentScreen = std::make_unique<Screens::QuickSettings>(
+        this, batteryController, dateTimeController, brightnessController, motorController, settingsController);
+      ReturnApp(Apps::Clock, FullRefreshDirections::LeftAnim, TouchEvents::SwipeLeft);
       break;
     case Apps::Settings:
       currentScreen = std::make_unique<Screens::Settings>(this, settingsController);
-      returnApp(Apps::QuickSettings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      ReturnApp(Apps::QuickSettings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::SettingWatchFace:
       currentScreen = std::make_unique<Screens::SettingWatchFace>(this, settingsController);
-      returnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::SettingTimeFormat:
       currentScreen = std::make_unique<Screens::SettingTimeFormat>(this, settingsController);
-      returnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::SettingWakeUp:
       currentScreen = std::make_unique<Screens::SettingWakeUp>(this, settingsController);
-      returnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::SettingDisplay:
       currentScreen = std::make_unique<Screens::SettingDisplay>(this, settingsController);
-      returnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::BatteryInfo:
       currentScreen = std::make_unique<Screens::BatteryInfo>(this, batteryController);
-      returnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::SysInfo:
       currentScreen =
         std::make_unique<Screens::SystemInfo>(this, dateTimeController, batteryController, brightnessController, bleController, watchdog);
-      returnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
       //
 
     case Apps::FlashLight:
       currentScreen = std::make_unique<Screens::FlashLight>(this, systemTask, brightnessController);
-      returnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::None);
+      ReturnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::None);
       break;
     case Apps::StopWatch:
       currentScreen = std::make_unique<Screens::StopWatch>(this);

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -103,7 +103,7 @@ namespace Pinetime {
       static void Process(void* instance);
       void InitHw();
       void Refresh();
-      void returnApp(Apps app, DisplayApp::FullRefreshDirections direction, TouchEvents touchEvent);
+      void ReturnApp(Apps app, DisplayApp::FullRefreshDirections direction, TouchEvents touchEvent);
       void LoadApp(Apps app, DisplayApp::FullRefreshDirections direction);
     };
   }


### PR DESCRIPTION
DisplayApp::ReturnApp was inconsistently named, this PR fixes that. There's also a few small whitespace changes that have slipped in since the autoformat PR.