### PR TITLE
Improved clang-tidy configuration for less noise

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,5 +22,9 @@ Checks: '*,
   -hicpp-no-assembler,
   -hicpp-avoid-c-arrays,
   -hicpp-uppercase-literal-suffix,
+  -hicpp-no-array-decay,
   -cert-err58-cpp,
   -cert-err60-cpp'
+CheckOptions:
+  - key: readability-function-cognitive-complexity.Threshold
+    value: 100


### PR DESCRIPTION
This PR disables a check that is just an alias to an another one plus fine-tunes the cognitive complexity threshold for less noise.