### PR TITLE
Notification title fix

### DIFF
--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -176,7 +176,17 @@ Notifications::NotificationItem::NotificationItem(const char* title,
   lv_obj_set_style_local_text_color(alert_type, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x888888));
   if (title == nullptr)
     title = "Notification";
+  char* pchar;
+  pchar = strchr(title, '\n');
+  while (pchar != nullptr) {
+    *pchar = ' ';
+    pchar =
+    pchar = strchr(pchar + 1, '\n');
+  }
   lv_label_set_text(alert_type, title);
+  lv_label_set_long_mode(alert_type, LV_LABEL_LONG_SROLL_CIRC);
+  lv_label_set_anim_speed(alert_type, 3);
+  lv_obj_set_width(alert_type, 180);
   lv_obj_align(alert_type, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 16);
 
   /////////


### PR DESCRIPTION
Long notification titles now scroll. Newlines get replaced with spaces to prevent the title being draw over the notification text