### PR TITLE
Used a macro for UUID generation, switched from C-style casts to reinterpret_cast, renamed callback

### DIFF
--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -18,117 +18,68 @@
 #include "MusicService.h"
 #include "systemtask/SystemTask.h"
 
-int MSCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
-  auto musicService = static_cast<Pinetime::Controllers::MusicService*>(arg);
-  return musicService->OnCommand(conn_handle, attr_handle, ctxt);
+int MusicCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
+  return static_cast<Pinetime::Controllers::MusicService*>(arg)->OnCommand(conn_handle, attr_handle, ctxt);
 }
 
 Pinetime::Controllers::MusicService::MusicService(Pinetime::System::SystemTask& system) : m_system(system) {
-  msUuid.value[14] = msId[0];
-  msUuid.value[15] = msId[1];
-
-  msEventCharUuid.value[12] = msEventCharId[0];
-  msEventCharUuid.value[13] = msEventCharId[1];
-  msEventCharUuid.value[14] = msId[0];
-  msEventCharUuid.value[15] = msId[1];
-
-  msStatusCharUuid.value[12] = msStatusCharId[0];
-  msStatusCharUuid.value[13] = msStatusCharId[1];
-  msStatusCharUuid.value[14] = msId[0];
-  msStatusCharUuid.value[15] = msId[1];
-
-  msTrackCharUuid.value[12] = msTrackCharId[0];
-  msTrackCharUuid.value[13] = msTrackCharId[1];
-  msTrackCharUuid.value[14] = msId[0];
-  msTrackCharUuid.value[15] = msId[1];
-
-  msArtistCharUuid.value[12] = msArtistCharId[0];
-  msArtistCharUuid.value[13] = msArtistCharId[1];
-  msArtistCharUuid.value[14] = msId[0];
-  msArtistCharUuid.value[15] = msId[1];
-
-  msAlbumCharUuid.value[12] = msAlbumCharId[0];
-  msAlbumCharUuid.value[13] = msAlbumCharId[1];
-  msAlbumCharUuid.value[14] = msId[0];
-  msAlbumCharUuid.value[15] = msId[1];
-
-  msPositionCharUuid.value[12] = msPositionCharId[0];
-  msPositionCharUuid.value[13] = msPositionCharId[1];
-  msPositionCharUuid.value[14] = msId[0];
-  msPositionCharUuid.value[15] = msId[1];
-
-  msTotalLengthCharUuid.value[12] = msTotalLengthCharId[0];
-  msTotalLengthCharUuid.value[13] = msTotalLengthCharId[1];
-  msTotalLengthCharUuid.value[14] = msId[0];
-  msTotalLengthCharUuid.value[15] = msId[1];
-
-  msTrackNumberCharUuid.value[12] = msTrackNumberCharId[0];
-  msTrackNumberCharUuid.value[13] = msTrackNumberCharId[1];
-  msTrackNumberCharUuid.value[14] = msId[0];
-  msTrackNumberCharUuid.value[15] = msId[1];
-
-  msTrackTotalCharUuid.value[12] = msTrackTotalCharId[0];
-  msTrackTotalCharUuid.value[13] = msTrackTotalCharId[1];
-  msTrackTotalCharUuid.value[14] = msId[0];
-  msTrackTotalCharUuid.value[15] = msId[1];
-
-  msPlaybackSpeedCharUuid.value[12] = msPlaybackSpeedCharId[0];
-  msPlaybackSpeedCharUuid.value[13] = msPlaybackSpeedCharId[1];
-  msPlaybackSpeedCharUuid.value[14] = msId[0];
-  msPlaybackSpeedCharUuid.value[15] = msId[1];
-
-  msRepeatCharUuid.value[12] = msRepeatCharId[0];
-  msRepeatCharUuid.value[13] = msRepeatCharId[1];
-  msRepeatCharUuid.value[14] = msId[0];
-  msRepeatCharUuid.value[15] = msId[1];
-
-  msShuffleCharUuid.value[12] = msShuffleCharId[0];
-  msShuffleCharUuid.value[13] = msShuffleCharId[1];
-  msShuffleCharUuid.value[14] = msId[0];
-  msShuffleCharUuid.value[15] = msId[1];
-
-  characteristicDefinition[0] = {.uuid = (ble_uuid_t*) (&msEventCharUuid),
-                                 .access_cb = MSCallback,
+  characteristicDefinition[0] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msEventCharUuid),
+                                 .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_NOTIFY,
                                  .val_handle = &eventHandle};
-  characteristicDefinition[1] = {
-    .uuid = (ble_uuid_t*) (&msStatusCharUuid), .access_cb = MSCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[2] = {
-    .uuid = (ble_uuid_t*) (&msTrackCharUuid), .access_cb = MSCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[3] = {
-    .uuid = (ble_uuid_t*) (&msArtistCharUuid), .access_cb = MSCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[4] = {
-    .uuid = (ble_uuid_t*) (&msAlbumCharUuid), .access_cb = MSCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[5] = {
-    .uuid = (ble_uuid_t*) (&msPositionCharUuid), .access_cb = MSCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[6] = {.uuid = (ble_uuid_t*) (&msTotalLengthCharUuid),
-                                 .access_cb = MSCallback,
+  characteristicDefinition[1] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msStatusCharUuid),
+                                 .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[7] = {.uuid = (ble_uuid_t*) (&msTotalLengthCharUuid),
-                                 .access_cb = MSCallback,
+  characteristicDefinition[2] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msTrackCharUuid),
+                                 .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[8] = {.uuid = (ble_uuid_t*) (&msTrackNumberCharUuid),
-                                 .access_cb = MSCallback,
+  characteristicDefinition[3] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msArtistCharUuid),
+                                 .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[9] = {.uuid = (ble_uuid_t*) (&msTrackTotalCharUuid),
-                                 .access_cb = MSCallback,
+  characteristicDefinition[4] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msAlbumCharUuid),
+                                 .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[10] = {.uuid = (ble_uuid_t*) (&msPlaybackSpeedCharUuid),
-                                  .access_cb = MSCallback,
+  characteristicDefinition[5] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msPositionCharUuid),
+                                 .access_cb = MusicCallback,
+                                 .arg = this,
+                                 .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+  characteristicDefinition[6] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msTotalLengthCharUuid),
+                                 .access_cb = MusicCallback,
+                                 .arg = this,
+                                 .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+  characteristicDefinition[7] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msTotalLengthCharUuid),
+                                 .access_cb = MusicCallback,
+                                 .arg = this,
+                                 .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+  characteristicDefinition[8] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msTrackNumberCharUuid),
+                                 .access_cb = MusicCallback,
+                                 .arg = this,
+                                 .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+  characteristicDefinition[9] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msTrackTotalCharUuid),
+                                 .access_cb = MusicCallback,
+                                 .arg = this,
+                                 .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+  characteristicDefinition[10] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msPlaybackSpeedCharUuid),
+                                  .access_cb = MusicCallback,
                                   .arg = this,
                                   .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[11] = {
-    .uuid = (ble_uuid_t*) (&msRepeatCharUuid), .access_cb = MSCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[12] = {
-    .uuid = (ble_uuid_t*) (&msShuffleCharUuid), .access_cb = MSCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+  characteristicDefinition[11] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msRepeatCharUuid),
+                                  .access_cb = MusicCallback,
+                                  .arg = this,
+                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+  characteristicDefinition[12] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msShuffleCharUuid),
+                                  .access_cb = MusicCallback,
+                                  .arg = this,
+                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
   characteristicDefinition[13] = {0};
 
-  serviceDefinition[0] = {.type = BLE_GATT_SVC_TYPE_PRIMARY, .uuid = (ble_uuid_t*) &msUuid, .characteristics = characteristicDefinition};
+  serviceDefinition[0] = {
+    .type = BLE_GATT_SVC_TYPE_PRIMARY, .uuid = reinterpret_cast<ble_uuid_t*>(&msUuid), .characteristics = characteristicDefinition};
   serviceDefinition[1] = {0};
 
   artistName = "Waiting for";
@@ -143,7 +94,7 @@ Pinetime::Controllers::MusicService::MusicService(Pinetime::System::SystemTask& 
 }
 
 void Pinetime::Controllers::MusicService::Init() {
-  int res = 0;
+  uint8_t res = 0;
   res = ble_gatts_count_cfg(serviceDefinition);
   ASSERT(res == 0);
 
@@ -152,58 +103,65 @@ void Pinetime::Controllers::MusicService::Init() {
 }
 
 int Pinetime::Controllers::MusicService::OnCommand(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
-
   if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
     size_t notifSize = OS_MBUF_PKTLEN(ctxt->om);
-    uint8_t data[notifSize + 1];
+    char data[notifSize + 1];
     data[notifSize] = '\0';
     os_mbuf_copydata(ctxt->om, 0, notifSize, data);
-    char* s = (char*) &data[0];
-    if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msArtistCharUuid) == 0) {
+    char* s = &data[0];
+    if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msArtistCharUuid)) == 0) {
       artistName = s;
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msTrackCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msTrackCharUuid)) == 0) {
       trackName = s;
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msAlbumCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msAlbumCharUuid)) == 0) {
       albumName = s;
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msStatusCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msStatusCharUuid)) == 0) {
       playing = s[0];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msRepeatCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msRepeatCharUuid)) == 0) {
       repeat = s[0];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msShuffleCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msShuffleCharUuid)) == 0) {
       shuffle = s[0];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msPositionCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msPositionCharUuid)) == 0) {
       trackProgress = (s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msTotalLengthCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msTotalLengthCharUuid)) == 0) {
       trackLength = (s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msTrackNumberCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msTrackNumberCharUuid)) == 0) {
       trackNumber = (s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msTrackTotalCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msTrackTotalCharUuid)) == 0) {
       tracksTotal = (s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &msPlaybackSpeedCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msPlaybackSpeedCharUuid)) == 0) {
       playbackSpeed = static_cast<float>(((s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3])) / 100.0f;
     }
   }
   return 0;
 }
 
-std::string Pinetime::Controllers::MusicService::getAlbum() {
+std::string Pinetime::Controllers::MusicService::getAlbum() const {
   return albumName;
 }
 
-std::string Pinetime::Controllers::MusicService::getArtist() {
+std::string Pinetime::Controllers::MusicService::getArtist() const {
   return artistName;
 }
 
-std::string Pinetime::Controllers::MusicService::getTrack() {
+std::string Pinetime::Controllers::MusicService::getTrack() const {
   return trackName;
 }
 
-bool Pinetime::Controllers::MusicService::isPlaying() {
+bool Pinetime::Controllers::MusicService::isPlaying() const {
   return playing;
 }
 
-float Pinetime::Controllers::MusicService::getPlaybackSpeed() {
+float Pinetime::Controllers::MusicService::getPlaybackSpeed() const {
   return playbackSpeed;
+}
+
+int Pinetime::Controllers::MusicService::getProgress() const {
+  return trackProgress;
+}
+
+int Pinetime::Controllers::MusicService::getTrackLength() const {
+  return trackLength;
 }
 
 void Pinetime::Controllers::MusicService::event(char event) {
@@ -216,12 +174,4 @@ void Pinetime::Controllers::MusicService::event(char event) {
   }
 
   ble_gattc_notify_custom(connectionHandle, eventHandle, om);
-}
-
-int Pinetime::Controllers::MusicService::getProgress() {
-  return trackProgress;
-}
-
-int Pinetime::Controllers::MusicService::getTrackLength() {
-  return trackLength;
 }

--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2020 JF, Adam Pigg, Avamander
+/*  Copyright (C) 2020-2021 JF, Adam Pigg, Avamander
 
     This file is part of InfiniTime.
 

--- a/src/components/ble/MusicService.h
+++ b/src/components/ble/MusicService.h
@@ -29,6 +29,8 @@
 // 00000000-78fc-48fe-8e23-433b3a1942d0
 #define MUSIC_SERVICE_UUID_BASE                                                                                                            \
   { 0xd0, 0x42, 0x19, 0x3a, 0x3b, 0x43, 0x23, 0x8e, 0xfe, 0x48, 0xfc, 0x78, 0x00, 0x00, 0x00, 0x00 }
+#define MUSIC_SERVICE_CHAR_UUID(x, y)                                                                                                      \
+  { 0xd0, 0x42, 0x19, 0x3a, 0x3b, 0x43, 0x23, 0x8e, 0xfe, 0x48, 0xfc, 0x78, x, y, 0x00, 0x00 }
 
 namespace Pinetime {
   namespace System {
@@ -46,19 +48,19 @@ namespace Pinetime {
 
       void event(char event);
 
-      std::string getArtist();
+      std::string getArtist() const;
 
-      std::string getTrack();
+      std::string getTrack() const;
 
-      std::string getAlbum();
+      std::string getAlbum() const;
 
-      int getProgress();
+      int getProgress() const;
 
-      int getTrackLength();
+      int getTrackLength() const;
 
-      float getPlaybackSpeed();
+      float getPlaybackSpeed() const;
 
-      bool isPlaying();
+      bool isPlaying() const;
 
       static const char EVENT_MUSIC_OPEN = 0xe0;
       static const char EVENT_MUSIC_PLAY = 0x00;
@@ -71,34 +73,20 @@ namespace Pinetime {
       enum MusicStatus { NotPlaying = 0x00, Playing = 0x01 };
 
     private:
-      static constexpr uint8_t msId[2] = {0x00, 0x00};
-      static constexpr uint8_t msEventCharId[2] = {0x01, 0x00};
-      static constexpr uint8_t msStatusCharId[2] = {0x02, 0x00};
-      static constexpr uint8_t msArtistCharId[2] = {0x03, 0x00};
-      static constexpr uint8_t msTrackCharId[2] = {0x04, 0x00};
-      static constexpr uint8_t msAlbumCharId[2] = {0x05, 0x00};
-      static constexpr uint8_t msPositionCharId[2] = {0x06, 0x00};
-      static constexpr uint8_t msTotalLengthCharId[2] = {0x07, 0x00};
-      static constexpr uint8_t msTrackNumberCharId[2] = {0x08, 0x00};
-      static constexpr uint8_t msTrackTotalCharId[2] = {0x09, 0x00};
-      static constexpr uint8_t msPlaybackSpeedCharId[2] = {0x0a, 0x00};
-      static constexpr uint8_t msRepeatCharId[2] = {0x0b, 0x00};
-      static constexpr uint8_t msShuffleCharId[2] = {0x0c, 0x00};
-
       ble_uuid128_t msUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
 
-      ble_uuid128_t msEventCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msStatusCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msArtistCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msTrackCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msAlbumCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msPositionCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msTotalLengthCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msTrackNumberCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msTrackTotalCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msPlaybackSpeedCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msRepeatCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-      ble_uuid128_t msShuffleCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
+      ble_uuid128_t msEventCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x01, 0x00)};
+      ble_uuid128_t msStatusCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x02, 0x00)};
+      ble_uuid128_t msArtistCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x03, 0x00)};
+      ble_uuid128_t msTrackCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x04, 0x00)};
+      ble_uuid128_t msAlbumCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x05, 0x00)};
+      ble_uuid128_t msPositionCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x06, 0x00)};
+      ble_uuid128_t msTotalLengthCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x07, 0x00)};
+      ble_uuid128_t msTrackNumberCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x08, 0x00)};
+      ble_uuid128_t msTrackTotalCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x09, 0x00)};
+      ble_uuid128_t msPlaybackSpeedCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x0a, 0x00)};
+      ble_uuid128_t msRepeatCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x0b, 0x00)};
+      ble_uuid128_t msShuffleCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x0c, 0x00)};
 
       struct ble_gatt_chr_def characteristicDefinition[14];
       struct ble_gatt_svc_def serviceDefinition[2];

--- a/src/components/ble/MusicService.h
+++ b/src/components/ble/MusicService.h
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2020 JF, Adam Pigg, Avamander
+/*  Copyright (C) 2020-2021 JF, Adam Pigg, Avamander
 
     This file is part of InfiniTime.
 


### PR DESCRIPTION
I tried to separate these changes a bit more, but couldn't.

The PR makes some minor improvements to the music watchapp:
1) Switches to a macro for UUID generation. I think this might save some RAM+ROM, but primarily gets rid of all these hard-to-read assignments in the constructor.
2) Switches from C-style casts to reinterpret_cast
3) To avoid a name conflict, renames MSCallback to MusicCallback, also did a minor variable inlining (that the compiler will also do above `-O0` very likely)
4) `const`-ified the value getters for more safety
5) Moved a few functions around a tiny bit to group getters

(It should remain functionally identical, at least my tests with GB didn't show any differences)

Let me know if I should strip out some of these changes. 

I would also really like to know if the macro is okay.