### PR TITLE
Turned sortById to a class method to avoid a name conflict

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -304,8 +304,6 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
         std::make_unique<Screens::SystemInfo>(this, dateTimeController, batteryController, brightnessController, bleController, watchdog);
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
-      //
-
     case Apps::FlashLight:
       currentScreen = std::make_unique<Screens::FlashLight>(this, systemTask, brightnessController);
       ReturnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::None);

--- a/src/displayapp/screens/SystemInfo.cpp
+++ b/src/displayapp/screens/SystemInfo.cpp
@@ -194,7 +194,7 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen3() {
   return std::unique_ptr<Screen>(new Screens::Label(2, 5, app, label));
 }
 
-bool sortById(const TaskStatus_t& lhs, const TaskStatus_t& rhs) {
+bool SystemInfo::sortById(const TaskStatus_t& lhs, const TaskStatus_t& rhs) {
   return lhs.xTaskNumber < rhs.xTaskNumber;
 }
 

--- a/src/displayapp/screens/SystemInfo.h
+++ b/src/displayapp/screens/SystemInfo.h
@@ -43,6 +43,9 @@ namespace Pinetime {
         Pinetime::Drivers::WatchdogView& watchdog;
 
         ScreenList<5> screens;
+
+        static bool sortById(const TaskStatus_t& lhs, const TaskStatus_t& rhs);
+
         std::unique_ptr<Screen> CreateScreen1();
         std::unique_ptr<Screen> CreateScreen2();
         std::unique_ptr<Screen> CreateScreen3();


### PR DESCRIPTION
This PR turns sortById into a class method to avoid a name conflict.

There's also a dangling comment I removed, felt weird to make a separate PR for that.