### PR TITLE
Navigation app: reduce memory usage

### DIFF
--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -25,7 +25,7 @@ using namespace Pinetime::Applications::Screens;
 LV_FONT_DECLARE(lv_font_navi_80)
 
 namespace {
-  static constexpr std::array<std::pair<const char*, const char*>, 86> m_iconMap = {{
+  constexpr std::array<std::pair<const char*, const char*>, 86> m_iconMap = {{
     {"arrive-left", "\xEE\xA4\x81"},
     {"arrive-right", "\xEE\xA4\x82"},
     {"arrive-straight", "\xEE\xA4\x80"},

--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -24,6 +24,106 @@ using namespace Pinetime::Applications::Screens;
 
 LV_FONT_DECLARE(lv_font_navi_80)
 
+namespace {
+  static constexpr std::array<std::pair<const char*, const char*>, 86> m_iconMap = {{
+    {"arrive-left", "\xEE\xA4\x81"},
+    {"arrive-right", "\xEE\xA4\x82"},
+    {"arrive-straight", "\xEE\xA4\x80"},
+    {"arrive", "\xEE\xA4\x80"},
+    {"close", "\xEE\xA4\x83"},
+    {"continue-left", "\xEE\xA4\x85"},
+    {"continue-right", "\xEE\xA4\x86"},
+    {"continue-slight-left", "\xEE\xA4\x87"},
+    {"continue-slight-right", "\xEE\xA4\x88"},
+    {"continue-straight", "\xEE\xA4\x84"},
+    {"continue-uturn", "\xEE\xA4\x89"},
+    {"continue", "\xEE\xA4\x84"},
+    {"depart-left", "\xEE\xA4\x8B"},
+    {"depart-right", "\xEE\xA4\x8C"},
+    {"depart-straight", "\xEE\xA4\x8A"},
+    {"end-of-road-left", "\xEE\xA4\x8D"},
+    {"end-of-road-right", "\xEE\xA4\x8E"},
+    {"ferry", "\xEE\xA4\x8F"},
+    {"flag", "\xEE\xA4\x90"},
+    {"fork-left", "\xEE\xA4\x92"},
+    {"fork-right", "\xEE\xA4\x93"},
+    {"fork-slight-left", "\xEE\xA4\x94"},
+    {"fork-slight-right", "\xEE\xA4\x95"},
+    {"fork-straight", "\xEE\xA4\x96"},
+    {"invalid", "\xEE\xA4\x84"},
+    {"invalid-left", "\xEE\xA4\x85"},
+    {"invalid-right", "\xEE\xA4\x86"},
+    {"invalid-slight-left", "\xEE\xA4\x87"},
+    {"invalid-slight-right", "\xEE\xA4\x88"},
+    {"invalid-straight", "\xEE\xA4\x84"},
+    {"invalid-uturn", "\xEE\xA4\x89"},
+    {"merge-left", "\xEE\xA4\x97"},
+    {"merge-right", "\xEE\xA4\x98"},
+    {"merge-slight-left", "\xEE\xA4\x99"},
+    {"merge-slight-right", "\xEE\xA4\x9A"},
+    {"merge-straight", "\xEE\xA4\x84"},
+    {"new-name-left", "\xEE\xA4\x85"},
+    {"new-name-right", "\xEE\xA4\x86"},
+    {"new-name-sharp-left", "\xEE\xA4\x9B"},
+    {"new-name-sharp-right", "\xEE\xA4\x9C"},
+    {"new-name-slight-left", "\xEE\xA4\x87"},
+    {"new-name-slight-right", "\xEE\xA4\x88"},
+    {"new-name-straight", "\xEE\xA4\x84"},
+    {"notification-left", "\xEE\xA4\x85"},
+    {"notification-right", "\xEE\xA4\x86"},
+    {"notification-sharp-left", "\xEE\xA4\x9B"},
+    {"notification-sharp-right", "\xEE\xA4\xA5"},
+    {"notification-slight-left", "\xEE\xA4\x87"},
+    {"notification-slight-right", "\xEE\xA4\x88"},
+    {"notification-straight", "\xEE\xA4\x84"},
+    {"off-ramp-left", "\xEE\xA4\x9D"},
+    {"off-ramp-right", "\xEE\xA4\x9E"},
+    {"off-ramp-slight-left", "\xEE\xA4\x9F"},
+    {"off-ramp-slight-right", "\xEE\xA4\xA0"},
+    {"on-ramp-left", "\xEE\xA4\x85"},
+    {"on-ramp-right", "\xEE\xA4\x86"},
+    {"on-ramp-sharp-left", "\xEE\xA4\x9B"},
+    {"on-ramp-sharp-right", "\xEE\xA4\xA5"},
+    {"on-ramp-slight-left", "\xEE\xA4\x87"},
+    {"on-ramp-slight-right", "\xEE\xA4\x88"},
+    {"on-ramp-straight", "\xEE\xA4\x84"},
+    {"rotary", "\xEE\xA4\xA1"},
+    {"rotary-left", "\xEE\xA4\xA2"},
+    {"rotary-right", "\xEE\xA4\xA3"},
+    {"rotary-sharp-left", "\xEE\xA4\xA4"},
+    {"rotary-sharp-right", "\xEE\xA4\xA5"},
+    {"rotary-slight-left", "\xEE\xA4\xA6"},
+    {"rotary-slight-right", "\xEE\xA4\xA7"},
+    {"rotary-straight", "\xEE\xA4\xA8"},
+    {"roundabout", "\xEE\xA4\xA1"},
+    {"roundabout-left", "\xEE\xA4\xA2"},
+    {"roundabout-right", "\xEE\xA4\xA3"},
+    {"roundabout-sharp-left", "\xEE\xA4\xA4"},
+    {"roundabout-sharp-right", "\xEE\xA4\xA5"},
+    {"roundabout-slight-left", "\xEE\xA4\xA6"},
+    {"roundabout-slight-right", "\xEE\xA4\xA7"},
+    {"roundabout-straight", "\xEE\xA4\xA8"},
+    {"turn-left", "\xEE\xA4\x85"},
+    {"turn-right", "\xEE\xA4\x86"},
+    {"turn-sharp-left", "\xEE\xA4\x9B"},
+    {"turn-sharp-right", "\xEE\xA4\xA5"},
+    {"turn-slight-left", "\xEE\xA4\x87"},
+    {"turn-slight-right", "\xEE\xA4\x88"},
+    {"turn-straight", "\xEE\xA4\x84"},
+    {"updown", "\xEE\xA4\xA9"},
+    {"uturn", "\xEE\xA4\x89"},
+  }};
+
+  const char* iconForName(const std::string& icon) {
+    for (auto iter : m_iconMap) {
+      if (iter.first == icon) {
+        return iter.second;
+      }
+    }
+    return "\xEE\xA4\x90";
+  }
+}
+
 /**
  * Navigation watchapp
  *
@@ -68,27 +168,25 @@ Navigation::~Navigation() {
 }
 
 bool Navigation::Refresh() {
-
-  if (m_flag != navService.getFlag()) {
-    m_flag = navService.getFlag();
-    lv_label_set_text(imgFlag, iconForName(m_flag));
-    // lv_img_set_src_arr(imgFlag, iconForName(m_flag));
+  if (flag != navService.getFlag()) {
+    flag = navService.getFlag();
+    lv_label_set_text(imgFlag, iconForName(flag));
   }
 
-  if (m_narrative != navService.getNarrative()) {
-    m_narrative = navService.getNarrative();
-    lv_label_set_text(txtNarrative, m_narrative.data());
+  if (narrative != navService.getNarrative()) {
+    narrative = navService.getNarrative();
+    lv_label_set_text(txtNarrative, narrative.data());
   }
 
-  if (m_manDist != navService.getManDist()) {
-    m_manDist = navService.getManDist();
-    lv_label_set_text(txtManDist, m_manDist.data());
+  if (manDist != navService.getManDist()) {
+    manDist = navService.getManDist();
+    lv_label_set_text(txtManDist, manDist.data());
   }
 
-  if (m_progress != navService.getProgress()) {
-    m_progress = navService.getProgress();
-    lv_bar_set_value(barProgress, m_progress, LV_ANIM_OFF);
-    if (m_progress > 90) {
+  if (progress != navService.getProgress()) {
+    progress = navService.getProgress();
+    lv_bar_set_value(barProgress, progress, LV_ANIM_OFF);
+    if (progress > 90) {
       lv_obj_set_style_local_bg_color(barProgress, LV_BAR_PART_INDIC, LV_STATE_DEFAULT, LV_COLOR_RED);
     } else {
       lv_obj_set_style_local_bg_color(barProgress, LV_BAR_PART_INDIC, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
@@ -98,11 +196,4 @@ bool Navigation::Refresh() {
   return running;
 }
 
-const char* Navigation::iconForName(std::string icon) {
-  for (auto iter : m_iconMap) {
-    if (iter.first == icon) {
-      return iter.second;
-    }
-  }
-  return "\xEE\xA4\x90";
-}
+

--- a/src/displayapp/screens/Navigation.h
+++ b/src/displayapp/screens/Navigation.h
@@ -45,103 +45,10 @@ namespace Pinetime {
 
         Pinetime::Controllers::NavigationService& navService;
 
-        std::string m_flag;
-        std::string m_narrative;
-        std::string m_manDist;
-        int m_progress;
-
-        /** Watchapp */
-
-        const char* iconForName(std::string icon);
-
-        std::array<std::pair<std::string, const char*>, 89> m_iconMap = {{
-          {"arrive-left", "\xEE\xA4\x81"},
-          {"arrive-right", "\xEE\xA4\x82"},
-          {"arrive-straight", "\xEE\xA4\x80"},
-          {"arrive", "\xEE\xA4\x80"},
-          {"close", "\xEE\xA4\x83"},
-          {"continue-left", "\xEE\xA4\x85"},
-          {"continue-right", "\xEE\xA4\x86"},
-          {"continue-slight-left", "\xEE\xA4\x87"},
-          {"continue-slight-right", "\xEE\xA4\x88"},
-          {"continue-straight", "\xEE\xA4\x84"},
-          {"continue-uturn", "\xEE\xA4\x89"},
-          {"continue", "\xEE\xA4\x84"},
-          {"depart-left", "\xEE\xA4\x8B"},
-          {"depart-right", "\xEE\xA4\x8C"},
-          {"depart-straight", "\xEE\xA4\x8A"},
-          {"end-of-road-left", "\xEE\xA4\x8D"},
-          {"end-of-road-right", "\xEE\xA4\x8E"},
-          {"ferry", "\xEE\xA4\x8F"},
-          {"flag", "\xEE\xA4\x90"},
-          {"fork-left", "\xEE\xA4\x92"},
-          {"fork-right", "\xEE\xA4\x93"},
-          {"fork-slight-left", "\xEE\xA4\x94"},
-          {"fork-slight-right", "\xEE\xA4\x95"},
-          {"fork-straight", "\xEE\xA4\x96"},
-          {"invalid", "\xEE\xA4\x84"},
-          {"invalid-left", "\xEE\xA4\x85"},
-          {"invalid-right", "\xEE\xA4\x86"},
-          {"invalid-slight-left", "\xEE\xA4\x87"},
-          {"invalid-slight-right", "\xEE\xA4\x88"},
-          {"invalid-straight", "\xEE\xA4\x84"},
-          {"invalid-uturn", "\xEE\xA4\x89"},
-          {"merge-left", "\xEE\xA4\x97"},
-          {"merge-right", "\xEE\xA4\x98"},
-          {"merge-slight-left", "\xEE\xA4\x99"},
-          {"merge-slight-right", "\xEE\xA4\x9A"},
-          {"merge-straight", "\xEE\xA4\x84"},
-          {"new-name-left", "\xEE\xA4\x85"},
-          {"new-name-right", "\xEE\xA4\x86"},
-          {"new-name-sharp-left", "\xEE\xA4\x9B"},
-          {"new-name-sharp-right", "\xEE\xA4\x9C"},
-          {"new-name-slight-left", "\xEE\xA4\x87"},
-          {"new-name-slight-right", "\xEE\xA4\x88"},
-          {"new-name-straight", "\xEE\xA4\x84"},
-          {"notification-left", "\xEE\xA4\x85"},
-          {"notification-right", "\xEE\xA4\x86"},
-          {"notification-sharp-left", "\xEE\xA4\x9B"},
-          {"notification-sharp-right", "\xEE\xA4\xA5"},
-          {"notification-slight-left", "\xEE\xA4\x87"},
-          {"notification-slight-right", "\xEE\xA4\x88"},
-          {"notification-straight", "\xEE\xA4\x84"},
-          {"off-ramp-left", "\xEE\xA4\x9D"},
-          {"off-ramp-right", "\xEE\xA4\x9E"},
-          {"off-ramp-slight-left", "\xEE\xA4\x9F"},
-          {"off-ramp-slight-right", "\xEE\xA4\xA0"},
-          {"on-ramp-left", "\xEE\xA4\x85"},
-          {"on-ramp-right", "\xEE\xA4\x86"},
-          {"on-ramp-sharp-left", "\xEE\xA4\x9B"},
-          {"on-ramp-sharp-right", "\xEE\xA4\xA5"},
-          {"on-ramp-slight-left", "\xEE\xA4\x87"},
-          {"on-ramp-slight-right", "\xEE\xA4\x88"},
-          {"on-ramp-straight", "\xEE\xA4\x84"},
-          {"rotary", "\xEE\xA4\xA1"},
-          {"rotary-left", "\xEE\xA4\xA2"},
-          {"rotary-right", "\xEE\xA4\xA3"},
-          {"rotary-sharp-left", "\xEE\xA4\xA4"},
-          {"rotary-sharp-right", "\xEE\xA4\xA5"},
-          {"rotary-slight-left", "\xEE\xA4\xA6"},
-          {"rotary-slight-right", "\xEE\xA4\xA7"},
-          {"rotary-straight", "\xEE\xA4\xA8"},
-          {"roundabout", "\xEE\xA4\xA1"},
-          {"roundabout-left", "\xEE\xA4\xA2"},
-          {"roundabout-right", "\xEE\xA4\xA3"},
-          {"roundabout-sharp-left", "\xEE\xA4\xA4"},
-          {"roundabout-sharp-right", "\xEE\xA4\xA5"},
-          {"roundabout-slight-left", "\xEE\xA4\xA6"},
-          {"roundabout-slight-right", "\xEE\xA4\xA7"},
-          {"roundabout-straight", "\xEE\xA4\xA8"},
-          {"turn-left", "\xEE\xA4\x85"},
-          {"turn-right", "\xEE\xA4\x86"},
-          {"turn-sharp-left", "\xEE\xA4\x9B"},
-          {"turn-sharp-right", "\xEE\xA4\xA5"},
-          {"turn-slight-left", "\xEE\xA4\x87"},
-          {"turn-slight-right", "\xEE\xA4\x88"},
-          {"turn-straight", "\xEE\xA4\x84"},
-          {"updown", "\xEE\xA4\xA9"},
-          {"uturn", "\xEE\xA4\x89"},
-        }};
+        std::string flag;
+        std::string narrative;
+        std::string manDist;
+        int progress;
       };
     }
   }


### PR DESCRIPTION
This PR slightly changes how `iconMap` is declared to reduce significantly the FLASH and RAM memory consumed by this app.

Before this change, `iconMap` was declare as a non-const member variable of Navigation. It means that this array was stored in FLASH. When Navigation was instantiated, the content of the flash was copied into RAM.
Also, `iconMap` was declared as `std::array<std::pair<std::string, const char*>, 89>`. Each item of the array was 28B long (24B for the string, 4B for the ptr to char). Using `const char*` instead of `std::string` frees 20B per element in the array.

Now, the array is declared as `static constexpr std::array<std::pair<const char*, const char*>, 86>` : 8B per element and it only lives in `.rodata` which is in FLASH. No need to copy it into RAM.

In the end, 5300B of flash were freed, and probably that much in the heap (RAM):
 - Before :  `424644	    960	  47676	 473280	  738c0	pinetime-app-1.0.0.out`
 - After    : `419344	    960	  47676	 467980	  7240c	pinetime-app-1.0.0.out`