### PR TITLE
Remove debug defines 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -746,14 +746,16 @@ link_directories(
 
 set(COMMON_FLAGS -MP -MD -mthumb -mabi=aapcs -Wall -Wno-unknown-pragmas -g3 -ffunction-sections -fdata-sections -fno-strict-aliasing -fno-builtin --short-enums -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -Wreturn-type -Werror=return-type)
 add_definitions(-DCONFIG_GPIO_AS_PINRESET)
-add_definitions(-DDEBUG)
 add_definitions(-DNIMBLE_CFG_CONTROLLER)
 add_definitions(-DOS_CPUTIME_FREQ)
 add_definitions(-DNRF52 -DNRF52832 -DNRF52832_XXAA -DNRF52_PAN_74 -DNRF52_PAN_64 -DNRF52_PAN_12 -DNRF52_PAN_58 -DNRF52_PAN_54 -DNRF52_PAN_31 -DNRF52_PAN_51 -DNRF52_PAN_36 -DNRF52_PAN_15 -DNRF52_PAN_20 -DNRF52_PAN_55 -DBOARD_PCA10040)
 add_definitions(-DFREERTOS)
-add_definitions(-DDEBUG_NRF_USER)
 add_definitions(-D__STACK_SIZE=8192)
 add_definitions(-D__HEAP_SIZE=8192)
+
+# NOTE : Add the following defines to enable debug mode of the NRF SDK:
+#add_definitions(-DDEBUG)
+#add_definitions(-DDEBUG_NRF_USER)
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")

--- a/src/FreeRTOS/port_cmsis.c
+++ b/src/FreeRTOS/port_cmsis.c
@@ -294,6 +294,25 @@ static void vPortEnableVFP( void )
 }
 /*-----------------------------------------------------------*/
 
+uint32_t ulSetInterruptMaskFromISR( void )
+{
+  __asm volatile (
+  " mrs r0, PRIMASK	\n"
+  " cpsid i			\n"
+  " bx lr				  "
+  ::: "memory"
+  );
+}
+
+void vClearInterruptMaskFromISR( __attribute__( ( unused ) ) uint32_t ulMask )
+{
+  __asm volatile (
+  " msr PRIMASK, r0	\n"
+  " bx lr				  "
+  ::: "memory"
+  );
+}
+
 #if ( configASSERT_DEFINED == 1 )
 
     void vPortValidateInterruptPriority( void )
@@ -353,25 +372,5 @@ static void vPortEnableVFP( void )
         of zero will result in unpredicable behaviour. */
         configASSERT( NVIC_GetPriorityGrouping() <= ulMaxPRIGROUPValue );
     }
-
-uint32_t ulSetInterruptMaskFromISR( void )
-{
-  __asm volatile (
-  " mrs r0, PRIMASK	\n"
-  " cpsid i			\n"
-  " bx lr				  "
-  ::: "memory"
-  );
-}
-/*-----------------------------------------------------------*/
-
-void vClearInterruptMaskFromISR( __attribute__( ( unused ) ) uint32_t ulMask )
-{
-  __asm volatile (
-  " msr PRIMASK, r0	\n"
-  " bx lr				  "
-  ::: "memory"
-  );
-}
 
 #endif /* configASSERT_DEFINED */


### PR DESCRIPTION
Remove debug defines (DEBUG & DEBUG_NRF_USER) from the build. These defines can be useful for debugging purposes but not in production (release).

This reduces the size of the binary by about 6KB!
This also removes filepath that were embedded into the binary (.bin) file.