### PR TITLE
Fix fallthrough on case statement

### DIFF
--- a/src/drivers/SpiMaster.cpp
+++ b/src/drivers/SpiMaster.cpp
@@ -53,6 +53,7 @@ bool SpiMaster::Init() {
       break;
     case BitOrder::Lsb_Msb:
       regConfig = 1;
+      break;
     default:
       return false;
   }


### PR DESCRIPTION
Fixes (presumably) unintentional case fallthrough in `SpiMaster.cpp`.

Closes #402 