### PR TITLE
Warning cleanup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -531,7 +531,6 @@ list(APPEND RECOVERY_SOURCE_FILES
         systemtask/SystemTask.cpp
         drivers/TwiMaster.cpp
         components/gfx/Gfx.cpp
-        displayapp/icons/infinitime/infinitime-nb.c
         components/rle/RleDecoder.cpp
         components/heartrate/HeartRateController.cpp
         heartratetask/HeartRateTask.cpp
@@ -558,7 +557,6 @@ list(APPEND RECOVERYLOADER_SOURCE_FILES
         drivers/St7789.cpp
         components/brightness/BrightnessController.cpp
 
-        displayapp/icons/infinitime/infinitime-nb.c
         recoveryLoader.cpp
         )
 

--- a/src/components/rle/RleDecoder.h
+++ b/src/components/rle/RleDecoder.h
@@ -21,7 +21,7 @@ namespace Pinetime {
       const uint8_t* buffer;
       size_t size;
 
-      int encodedBufferIndex = 0;
+      size_t encodedBufferIndex = 0;
       int y = 0;
       uint16_t bp = 0;
       uint16_t foregroundColor = 0xffff;


### PR DESCRIPTION
Fix compiler warnings present in `pinetime-recovery` and `pinetime-recovery-loader` build targets.