### PR TITLE
Replace raw new expressions with make_unique

### DIFF
--- a/src/displayapp/screens/SystemInfo.cpp
+++ b/src/displayapp/screens/SystemInfo.cpp
@@ -81,7 +81,7 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen1() {
                         __TIME__);
   lv_label_set_align(label, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(label, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
-  return std::unique_ptr<Screen>(new Screens::Label(0, 5, app, label));
+  return std::make_unique<Screens::Label>(0, 5, app, label);
 }
 
 std::unique_ptr<Screen> SystemInfo::CreateScreen2() {
@@ -161,7 +161,7 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen2() {
                         brightnessController.ToString(),
                         resetReason);
   lv_obj_align(label, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
-  return std::unique_ptr<Screen>(new Screens::Label(1, 4, app, label));
+  return std::make_unique<Screens::Label>(1, 4, app, label);
 }
 
 std::unique_ptr<Screen> SystemInfo::CreateScreen3() {
@@ -193,7 +193,7 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen3() {
                         (int) mon.free_biggest_size,
                         0);
   lv_obj_align(label, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
-  return std::unique_ptr<Screen>(new Screens::Label(2, 5, app, label));
+  return std::make_unique<Screens::Label>(2, 5, app, label);
 }
 
 bool sortById(const TaskStatus_t& lhs, const TaskStatus_t& rhs) {
@@ -227,7 +227,7 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen4() {
       lv_table_set_cell_value(infoTask, i + 1, 2, std::to_string(tasksStatus[i].usStackHighWaterMark).c_str());
     }
   }
-  return std::unique_ptr<Screen>(new Screens::Label(3, 5, app, infoTask));
+  return std::make_unique<Screens::Label>(3, 5, app, infoTask);
 }
 
 std::unique_ptr<Screen> SystemInfo::CreateScreen5() {
@@ -243,5 +243,5 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen5() {
                            "#FFFF00 JF002/InfiniTime#");
   lv_label_set_align(label, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(label, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
-  return std::unique_ptr<Screen>(new Screens::Label(4, 5, app, label));
+  return std::make_unique<Screens::Label>(4, 5, app, label);
 }

--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<Screen> Settings::CreateScreen1() {
     {Symbols::clock, "Watch face", Apps::SettingWatchFace},
   }};
 
-  return std::unique_ptr<Screen>(new Screens::List(0, 2, app, settingsController, applications));
+  return std::make_unique<Screens::List>(0, 2, app, settingsController, applications);
 }
 
 std::unique_ptr<Screen> Settings::CreateScreen2() {
@@ -58,5 +58,5 @@ std::unique_ptr<Screen> Settings::CreateScreen2() {
     {Symbols::list, "About", Apps::SysInfo},
   }};
 
-  return std::unique_ptr<Screen>(new Screens::List(1, 2, app, settingsController, applications));
+  return std::make_unique<Screens::List>(1, 2, app, settingsController, applications);
 }


### PR DESCRIPTION
Using make_unique avoids needing to repeat type information making it
less verbose. Also fixes clang-tidy warning modernize-make-unique.