### PR TITLE
Allow DFU only builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (NOT NRF5_SDK_PATH)
   message(FATAL_ERROR "The path to the NRF52 SDK must be specified on the command line (add -DNRF5_SDK_PATH=<path>")
 endif ()
 
-if(NOT USE_JLINK AND NOT USE_GDB_CLIENT AND NOT USE_OPENOCD)
+if(NOT USE_JLINK AND NOT USE_GDB_CLIENT AND NOT USE_OPENOCD AND NOT BUILD_DFU)
   set(USE_JLINK true)
 endif()
 


### PR DESCRIPTION
Adds a check so that USE_JLINK, USE_GDB_CLIENT and USE_OPENOCD can all be disabled if BUILD_DFU=1. This allows DFU only builds.

Fixes https://github.com/JF002/InfiniTime/issues/384

Tested by running: 
```bash
mkdir build
cd build
cmake .. -DBUILD_DFU=1 -DNRF5_SDK_PATH=/home/martin/dev/nRF5_SDK_15.3.0_59ac345 -DARM_NONE_EABI_TOOLCHAIN_PATH=/home/martin/dev/gcc-arm-none-eabi-9-2020-q2-update
make -j4
```
And checking that a DFU file is produced at build/src/pinetime-mcuboot-app-dfu-1.1.0.zip.