### PR TITLE
Remove tap to switch Watchfaces

### DIFF
--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -32,22 +32,25 @@ Clock::Clock(DisplayApp* app,
     notificatioManager {notificatioManager},
     settingsController {settingsController},
     heartRateController {heartRateController},
-    motionController {motionController},
-    screens {app,
-             settingsController.GetClockFace(),
-             {
-               [this]() -> std::unique_ptr<Screen> {
-                 return WatchFaceDigitalScreen();
-               },
-               [this]() -> std::unique_ptr<Screen> {
-                 return WatchFaceAnalogScreen();
-               },
-               // Examples for more watch faces
-               //[this]() -> std::unique_ptr<Screen> { return WatchFaceMinimalScreen(); },
-               //[this]() -> std::unique_ptr<Screen> { return WatchFaceCustomScreen(); }
-             },
-             Screens::ScreenListModes::LongPress} {
-
+    motionController {motionController} {
+  
+  switch (settingsController.GetClockFace()) {
+    case 0:
+      screen = WatchFaceDigitalScreen();
+      break;
+    case 1:
+      screen = WatchFaceAnalogScreen();
+      break;
+    /*
+    // Examples for more watch faces
+    case 2:
+      screen = WatchFaceMinimalScreen();
+      break;
+    case 3:
+      screen = WatchFaceCustomScreen();
+      break;
+    */
+  }
   settingsController.SetAppMenu(0);
 }
 
@@ -56,12 +59,12 @@ Clock::~Clock() {
 }
 
 bool Clock::Refresh() {
-  screens.Refresh();
+  screen->Refresh();
   return running;
 }
 
 bool Clock::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
-  return screens.OnTouchEvent(event);
+  return screen->OnTouchEvent(event);
 }
 
 std::unique_ptr<Screen> Clock::WatchFaceDigitalScreen() {

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -4,8 +4,8 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <components/heartrate/HeartRateController.h>
 #include "Screen.h"
-#include "ScreenList.h"
 #include "components/datetime/DateTimeController.h"
 
 namespace Pinetime {
@@ -47,7 +47,7 @@ namespace Pinetime {
         Controllers::HeartRateController& heartRateController;
         Controllers::MotionController& motionController;
 
-        ScreenList<2> screens;
+        std::unique_ptr<Screen> screen;
         std::unique_ptr<Screen> WatchFaceDigitalScreen();
         std::unique_ptr<Screen> WatchFaceAnalogScreen();
 


### PR DESCRIPTION
resolves #377 
this also allows Clock to just keep a single screen pointer instead of a ScreenList