### PR TITLE
Music service cleanup

### DIFF
--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -111,16 +111,6 @@ Pinetime::Controllers::MusicService::MusicService(Pinetime::System::SystemTask& 
   serviceDefinition[0] = {
     .type = BLE_GATT_SVC_TYPE_PRIMARY, .uuid = &msUuid.u, .characteristics = characteristicDefinition};
   serviceDefinition[1] = {0};
-
-  artistName = "Waiting for";
-  albumName = "";
-  trackName = "track information..";
-  playing = false;
-  repeat = false;
-  shuffle = false;
-  playbackSpeed = 1.0f;
-  trackProgress = 0;
-  trackLength = 0;
 }
 
 void Pinetime::Controllers::MusicService::Init() {

--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -47,10 +47,9 @@ namespace {
   constexpr ble_uuid128_t msRepeatCharUuid {CharUuid(0x0b, 0x00)};
   constexpr ble_uuid128_t msShuffleCharUuid {CharUuid(0x0c, 0x00)};
 
-}
-
-int MusicCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
-  return static_cast<Pinetime::Controllers::MusicService*>(arg)->OnCommand(conn_handle, attr_handle, ctxt);
+  int MusicCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
+    return static_cast<Pinetime::Controllers::MusicService*>(arg)->OnCommand(conn_handle, attr_handle, ctxt);
+  }
 }
 
 Pinetime::Controllers::MusicService::MusicService(Pinetime::System::SystemTask& system) : m_system(system) {

--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -18,6 +18,37 @@
 #include "MusicService.h"
 #include "systemtask/SystemTask.h"
 
+namespace {
+  // 0000yyxx-78fc-48fe-8e23-433b3a1942d0
+  constexpr ble_uuid128_t CharUuid(uint8_t x, uint8_t y) {
+    return ble_uuid128_t{
+      .u = {.type = BLE_UUID_TYPE_128},
+      .value =  { 0xd0, 0x42, 0x19, 0x3a, 0x3b, 0x43, 0x23, 0x8e, 0xfe, 0x48, 0xfc, 0x78, x, y, 0x00, 0x00 }
+    };
+  }
+
+  // 00000000-78fc-48fe-8e23-433b3a1942d0
+  constexpr ble_uuid128_t BaseUuid() {
+    return CharUuid(0x00, 0x00);
+  }
+
+  constexpr ble_uuid128_t msUuid {BaseUuid()};
+
+  constexpr ble_uuid128_t msEventCharUuid {CharUuid(0x01, 0x00)};
+  constexpr ble_uuid128_t msStatusCharUuid {CharUuid(0x02, 0x00)};
+  constexpr ble_uuid128_t msArtistCharUuid {CharUuid(0x03, 0x00)};
+  constexpr ble_uuid128_t msTrackCharUuid {CharUuid(0x04, 0x00)};
+  constexpr ble_uuid128_t msAlbumCharUuid {CharUuid(0x05, 0x00)};
+  constexpr ble_uuid128_t msPositionCharUuid {CharUuid(0x06, 0x00)};
+  constexpr ble_uuid128_t msTotalLengthCharUuid {CharUuid(0x07, 0x00)};
+  constexpr ble_uuid128_t msTrackNumberCharUuid {CharUuid(0x08, 0x00)};
+  constexpr ble_uuid128_t msTrackTotalCharUuid {CharUuid(0x09, 0x00)};
+  constexpr ble_uuid128_t msPlaybackSpeedCharUuid {CharUuid(0x0a, 0x00)};
+  constexpr ble_uuid128_t msRepeatCharUuid {CharUuid(0x0b, 0x00)};
+  constexpr ble_uuid128_t msShuffleCharUuid {CharUuid(0x0c, 0x00)};
+
+}
+
 int MusicCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
   return static_cast<Pinetime::Controllers::MusicService*>(arg)->OnCommand(conn_handle, attr_handle, ctxt);
 }

--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -23,63 +23,63 @@ int MusicCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_ac
 }
 
 Pinetime::Controllers::MusicService::MusicService(Pinetime::System::SystemTask& system) : m_system(system) {
-  characteristicDefinition[0] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msEventCharUuid),
+  characteristicDefinition[0] = {.uuid = &msEventCharUuid.u,
                                  .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_NOTIFY,
                                  .val_handle = &eventHandle};
-  characteristicDefinition[1] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msStatusCharUuid),
+  characteristicDefinition[1] = {.uuid = &msStatusCharUuid.u,
                                  .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[2] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msTrackCharUuid),
+  characteristicDefinition[2] = {.uuid = &msTrackCharUuid.u,
                                  .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[3] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msArtistCharUuid),
+  characteristicDefinition[3] = {.uuid = &msArtistCharUuid.u,
                                  .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[4] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msAlbumCharUuid),
+  characteristicDefinition[4] = {.uuid = &msAlbumCharUuid.u,
                                  .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[5] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msPositionCharUuid),
+  characteristicDefinition[5] = {.uuid = &msPositionCharUuid.u,
                                  .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[6] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msTotalLengthCharUuid),
+  characteristicDefinition[6] = {.uuid = &msTotalLengthCharUuid.u,
                                  .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[7] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msTotalLengthCharUuid),
+  characteristicDefinition[7] = {.uuid = &msTotalLengthCharUuid.u,
                                  .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[8] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msTrackNumberCharUuid),
+  characteristicDefinition[8] = {.uuid = &msTrackNumberCharUuid.u,
                                  .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[9] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msTrackTotalCharUuid),
+  characteristicDefinition[9] = {.uuid = &msTrackTotalCharUuid.u,
                                  .access_cb = MusicCallback,
                                  .arg = this,
                                  .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[10] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msPlaybackSpeedCharUuid),
+  characteristicDefinition[10] = {.uuid = &msPlaybackSpeedCharUuid.u,
                                   .access_cb = MusicCallback,
                                   .arg = this,
                                   .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[11] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msRepeatCharUuid),
+  characteristicDefinition[11] = {.uuid = &msRepeatCharUuid.u,
                                   .access_cb = MusicCallback,
                                   .arg = this,
                                   .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[12] = {.uuid = reinterpret_cast<ble_uuid_t*>(&msShuffleCharUuid),
+  characteristicDefinition[12] = {.uuid = &msShuffleCharUuid.u,
                                   .access_cb = MusicCallback,
                                   .arg = this,
                                   .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
   characteristicDefinition[13] = {0};
 
   serviceDefinition[0] = {
-    .type = BLE_GATT_SVC_TYPE_PRIMARY, .uuid = reinterpret_cast<ble_uuid_t*>(&msUuid), .characteristics = characteristicDefinition};
+    .type = BLE_GATT_SVC_TYPE_PRIMARY, .uuid = &msUuid.u, .characteristics = characteristicDefinition};
   serviceDefinition[1] = {0};
 
   artistName = "Waiting for";
@@ -109,27 +109,27 @@ int Pinetime::Controllers::MusicService::OnCommand(uint16_t conn_handle, uint16_
     data[notifSize] = '\0';
     os_mbuf_copydata(ctxt->om, 0, notifSize, data);
     char* s = &data[0];
-    if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msArtistCharUuid)) == 0) {
+    if (ble_uuid_cmp(ctxt->chr->uuid, &msArtistCharUuid.u) == 0) {
       artistName = s;
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msTrackCharUuid)) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &msTrackCharUuid.u) == 0) {
       trackName = s;
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msAlbumCharUuid)) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &msAlbumCharUuid.u) == 0) {
       albumName = s;
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msStatusCharUuid)) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &msStatusCharUuid.u) == 0) {
       playing = s[0];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msRepeatCharUuid)) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &msRepeatCharUuid.u) == 0) {
       repeat = s[0];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msShuffleCharUuid)) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &msShuffleCharUuid.u) == 0) {
       shuffle = s[0];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msPositionCharUuid)) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &msPositionCharUuid.u) == 0) {
       trackProgress = (s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msTotalLengthCharUuid)) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &msTotalLengthCharUuid.u) == 0) {
       trackLength = (s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msTrackNumberCharUuid)) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &msTrackNumberCharUuid.u) == 0) {
       trackNumber = (s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msTrackTotalCharUuid)) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &msTrackTotalCharUuid.u) == 0) {
       tracksTotal = (s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3];
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, reinterpret_cast<ble_uuid_t*>(&msPlaybackSpeedCharUuid)) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &msPlaybackSpeedCharUuid.u) == 0) {
       playbackSpeed = static_cast<float>(((s[0] << 24) | (s[1] << 16) | (s[2] << 8) | s[3])) / 100.0f;
     }
   }

--- a/src/components/ble/MusicService.h
+++ b/src/components/ble/MusicService.h
@@ -69,23 +69,23 @@ namespace Pinetime {
       struct ble_gatt_chr_def characteristicDefinition[14];
       struct ble_gatt_svc_def serviceDefinition[2];
 
-      uint16_t eventHandle;
+      uint16_t eventHandle {};
 
-      std::string artistName;
-      std::string albumName;
-      std::string trackName;
+      std::string artistName {"Waiting for"};
+      std::string albumName {};
+      std::string trackName {"track information.."};
 
-      bool playing;
+      bool playing {false};
 
-      int trackProgress;
-      int trackLength;
-      int trackNumber;
-      int tracksTotal;
+      int trackProgress {0};
+      int trackLength {0};
+      int trackNumber {};
+      int tracksTotal {};
 
-      float playbackSpeed;
+      float playbackSpeed {1.0f};
 
-      bool repeat;
-      bool shuffle;
+      bool repeat {false};
+      bool shuffle {false};
 
       Pinetime::System::SystemTask& m_system;
     };

--- a/src/components/ble/MusicService.h
+++ b/src/components/ble/MusicService.h
@@ -26,18 +26,11 @@
 #undef max
 #undef min
 
-// 00000000-78fc-48fe-8e23-433b3a1942d0
-#define MUSIC_SERVICE_UUID_BASE                                                                                                            \
-  { 0xd0, 0x42, 0x19, 0x3a, 0x3b, 0x43, 0x23, 0x8e, 0xfe, 0x48, 0xfc, 0x78, 0x00, 0x00, 0x00, 0x00 }
-#define MUSIC_SERVICE_CHAR_UUID(x, y)                                                                                                      \
-  { 0xd0, 0x42, 0x19, 0x3a, 0x3b, 0x43, 0x23, 0x8e, 0xfe, 0x48, 0xfc, 0x78, x, y, 0x00, 0x00 }
-
 namespace Pinetime {
   namespace System {
     class SystemTask;
   }
   namespace Controllers {
-
     class MusicService {
     public:
       explicit MusicService(Pinetime::System::SystemTask& system);
@@ -73,21 +66,6 @@ namespace Pinetime {
       enum MusicStatus { NotPlaying = 0x00, Playing = 0x01 };
 
     private:
-      ble_uuid128_t msUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_UUID_BASE};
-
-      ble_uuid128_t msEventCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x01, 0x00)};
-      ble_uuid128_t msStatusCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x02, 0x00)};
-      ble_uuid128_t msArtistCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x03, 0x00)};
-      ble_uuid128_t msTrackCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x04, 0x00)};
-      ble_uuid128_t msAlbumCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x05, 0x00)};
-      ble_uuid128_t msPositionCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x06, 0x00)};
-      ble_uuid128_t msTotalLengthCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x07, 0x00)};
-      ble_uuid128_t msTrackNumberCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x08, 0x00)};
-      ble_uuid128_t msTrackTotalCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x09, 0x00)};
-      ble_uuid128_t msPlaybackSpeedCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x0a, 0x00)};
-      ble_uuid128_t msRepeatCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x0b, 0x00)};
-      ble_uuid128_t msShuffleCharUuid {.u = {.type = BLE_UUID_TYPE_128}, .value = MUSIC_SERVICE_CHAR_UUID(0x0c, 0x00)};
-
       struct ble_gatt_chr_def characteristicDefinition[14];
       struct ble_gatt_svc_def serviceDefinition[2];
 


### PR DESCRIPTION
@Avamander here are the changes I mentioned in #359 plus one or two other small improvements.

1. Eliminated the need for `reinterpret_cast<ble_uuid_t*>`ing by passing pointers to the first member of the UUID structs, which is a `ble_uuid_t`, instead of the struct itself.
2. Replaced the macro definitions for the UUID values with `constexpr` functions that return UUID objects directly and used those to initialize them. Also moved these variables to static values in the source file since that's the only place they're referenced.
3. Moved `MusicCallback` into the anonymous namespace since it's also only referenced inside of `MusicService.cpp`
4. Moved initialization of member variables with fixed constants to class declaration in the header and added explicit initializers for some uninitialized members.

Another thing I was thinking of doing was adding a simple `operator==` for the UUID objects, which would just call `ble_uuid_cmp`. That would help make the if-chain in `MusicService::OnCommand` a lot cleaner to read.