### PR TITLE
Disable vibration while charging

### DIFF
--- a/src/components/motor/MotorController.cpp
+++ b/src/components/motor/MotorController.cpp
@@ -7,7 +7,8 @@ APP_TIMER_DEF(vibTimer);
 
 using namespace Pinetime::Controllers;
 
-MotorController::MotorController(Controllers::Settings& settingsController) : settingsController {settingsController} {
+MotorController::MotorController(Controllers::Settings& settingsController, Controllers::Battery& batteryController)
+  : settingsController {settingsController}, batteryController {batteryController} {
 }
 
 void MotorController::Init() {
@@ -19,6 +20,8 @@ void MotorController::Init() {
 void MotorController::SetDuration(uint8_t motorDuration) {
 
   if (settingsController.GetVibrationStatus() == Controllers::Settings::Vibration::OFF)
+    return;
+  if (batteryController.IsCharging())
     return;
 
   nrf_gpio_pin_clear(pinMotor);

--- a/src/components/motor/MotorController.h
+++ b/src/components/motor/MotorController.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include "app_timer.h"
 #include "components/settings/Settings.h"
+#include "components/battery/BatteryController.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -10,11 +11,12 @@ namespace Pinetime {
 
     class MotorController {
     public:
-      MotorController(Controllers::Settings& settingsController);
+      MotorController(Controllers::Settings& settingsController, Controllers::Battery& batteryController);
       void Init();
       void SetDuration(uint8_t motorDuration);
 
     private:
+      Controllers::Battery& batteryController;
       Controllers::Settings& settingsController;
       static void vibrate(void* p_context);
     };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ static constexpr uint8_t pinPowerPresentIrq = 19;
 
 Pinetime::Controllers::Settings settingsController {spiNorFlash};
 
-Pinetime::Controllers::MotorController motorController {settingsController};
+Pinetime::Controllers::MotorController motorController {settingsController, batteryController};
 
 Pinetime::Controllers::HeartRateController heartRateController;
 Pinetime::Applications::HeartRateTask heartRateApp(heartRateSensor, heartRateController);

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -305,8 +305,8 @@ void SystemTask::Work() {
           stepCounterMustBeReset = true;
           break;
         case Messages::OnChargingEvent:
-          motorController.SetDuration(15);
-	  // Battery level is updated on every message - there's no need to do anything
+          GoToRunning();
+          // Battery level is updated on every message - there's no need to do anything
           break;
 
         default:


### PR DESCRIPTION
I don't think having vibrations while charging is useful, and it makes unpleasant noises.

Fixes #446

Previously on OnChargingEvent, the watch would vibrate. I changed it so the watch wakes up instead. This is how most devices behave.