### PR TITLE
Removed an illogical comparison from SystemInfo and St7789 driver

### DIFF
--- a/src/displayapp/screens/SystemInfo.cpp
+++ b/src/displayapp/screens/SystemInfo.cpp
@@ -141,9 +141,6 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen2() {
   uptimeSeconds = uptimeSeconds % secondsInAMinute;
   // TODO handle more than 100 days of uptime
 
-  if (batteryPercent == -1)
-    batteryPercent = 0;
-
   // hack to not use the flot functions from printf
   uint8_t batteryVoltageBytes[2];
   batteryVoltageBytes[1] = static_cast<uint8_t>(batteryVoltage); // truncate whole numbers

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -140,8 +140,9 @@ void St7789::Uninit() {
 }
 
 void St7789::DrawPixel(uint16_t x, uint16_t y, uint32_t color) {
-  if ((x < 0) || (x >= Width) || (y < 0) || (y >= Height))
+  if (x >= Width || y >= Height) {
     return;
+  }
 
   SetAddrWindow(x, y, x + 1, y + 1);
 


### PR DESCRIPTION
This PR removes a few illogical lines from SystemInfo screen and the St7789 driver.

`batteryPercent` is cast to unsigned integer, the comparison is never true. The arguments in St7789 driver are both unsigned.