### PR TITLE
Dim screen before sleep

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -131,8 +131,15 @@ void DisplayApp::Refresh() {
   Messages msg;
   if (xQueueReceive(msgQueue, &msg, queueTimeout)) {
     switch (msg) {
-      case Messages::GoToSleep:
+      case Messages::DimScreen:
+        // Backup brightness is the brightness to return to after dimming or sleeping
         brightnessController.Backup();
+        brightnessController.Set(Controllers::BrightnessController::Levels::Low);
+        break;
+      case Messages::RestoreBrightness:
+        brightnessController.Restore();
+        break;
+      case Messages::GoToSleep:
         while (brightnessController.Level() != Controllers::BrightnessController::Levels::Off) {
           brightnessController.Lower();
           vTaskDelay(100);
@@ -191,6 +198,8 @@ void DisplayApp::Refresh() {
             }
           } else if (returnTouchEvent == gesture) {
             LoadApp(returnToApp, returnDirection);
+            brightnessController.Set(settingsController.GetBrightness());
+            brightnessController.Backup();
           }
         }
       } break;
@@ -200,6 +209,8 @@ void DisplayApp::Refresh() {
         } else {
           if (!currentScreen->OnButtonPushed()) {
             LoadApp(returnToApp, returnDirection);
+            brightnessController.Set(settingsController.GetBrightness());
+            brightnessController.Backup();
           }
         }
         break;

--- a/src/displayapp/Messages.h
+++ b/src/displayapp/Messages.h
@@ -13,7 +13,9 @@ namespace Pinetime {
         NewNotification,
         TimerDone,
         BleFirmwareUpdateStarted,
-        UpdateTimeOut
+        UpdateTimeOut,
+        DimScreen,
+        RestoreBrightness
       };
     }
   }

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -108,7 +108,6 @@ namespace Pinetime {
       Pinetime::Drivers::Bma421& motionSensor;
       Pinetime::Controllers::Settings& settingsController;
       Pinetime::Controllers::HeartRateController& heartRateController;
-      Controllers::BrightnessController brightnessController;
       Pinetime::Controllers::MotionController& motionController;
 
       Pinetime::Applications::DisplayApp& displayApp;

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -68,6 +68,7 @@ namespace Pinetime {
       void OnTouchEvent();
 
       void OnIdle();
+      void OnDim();
 
       Pinetime::Controllers::NimbleController& nimble() {
         return nimbleController;
@@ -96,6 +97,7 @@ namespace Pinetime {
       std::atomic<bool> isSleeping {false};
       std::atomic<bool> isGoingToSleep {false};
       std::atomic<bool> isWakingUp {false};
+      std::atomic<bool> isDimmed {false};
       Pinetime::Drivers::Watchdog& watchdog;
       Pinetime::Controllers::NotificationManager& notificationManager;
       Pinetime::Controllers::MotorController& motorController;
@@ -104,7 +106,6 @@ namespace Pinetime {
       Pinetime::Controllers::Settings& settingsController;
       Pinetime::Controllers::HeartRateController& heartRateController;
       Pinetime::Controllers::NimbleController nimbleController;
-      Controllers::BrightnessController brightnessController;
       Pinetime::Controllers::MotionController& motionController;
 
       Pinetime::Applications::DisplayApp& displayApp;
@@ -122,9 +123,10 @@ namespace Pinetime {
 
       static void Process(void* instance);
       void Work();
-      void ReloadIdleTimer() const;
+      void ReloadIdleTimer();
       bool isBleDiscoveryTimerRunning = false;
       uint8_t bleDiscoveryTimer = 0;
+      TimerHandle_t dimTimer;
       TimerHandle_t idleTimer;
       bool doNotGoToSleep = false;
 


### PR DESCRIPTION
Dims the screen to lowest brightness two seconds before going to sleep. This gives time for the user to refresh the idle timer by tapping the screen if the watch is about to go to sleep.