### PR TITLE
Condense firmware validation code

### DIFF
--- a/src/displayapp/screens/FirmwareValidation.cpp
+++ b/src/displayapp/screens/FirmwareValidation.cpp
@@ -16,30 +16,17 @@ namespace {
 
 FirmwareValidation::FirmwareValidation(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::FirmwareValidator& validator)
   : Screen {app}, validator {validator} {
-  labelVersionInfo = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_align(labelVersionInfo, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
-  lv_label_set_text(labelVersionInfo, "Version : ");
-  lv_label_set_align(labelVersionInfo, LV_LABEL_ALIGN_LEFT);
-
-  labelVersionValue = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_align(labelVersionValue, labelVersionInfo, LV_ALIGN_OUT_RIGHT_MID, 0, 0);
-  lv_label_set_recolor(labelVersionValue, true);
-  sprintf(version, "%ld.%ld.%ld", Version::Major(), Version::Minor(), Version::Patch());
-  lv_label_set_text(labelVersionValue, version);
-
-  labelShortRefInfo = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_align(labelShortRefInfo, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 25);
-  lv_label_set_text(labelShortRefInfo, "ShortRef : ");
-  lv_label_set_align(labelShortRefInfo, LV_LABEL_ALIGN_LEFT);
-
-  labelShortRefValue = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_align(labelShortRefValue, labelShortRefInfo, LV_ALIGN_OUT_RIGHT_MID, 0, 0);
-  lv_label_set_recolor(labelShortRefValue, true);
-  sprintf(shortref, "%s", Version::GitCommitHash());
-  lv_label_set_text(labelShortRefValue, shortref);
+  labelVersion = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_fmt(labelVersion, "Version : %d.%d.%d\n"
+                                      "ShortRef : %s",
+                                      Version::Major(),
+                                      Version::Minor(),
+                                      Version::Patch(),
+                                      Version::GitCommitHash());
+  lv_obj_align(labelVersion, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
 
   labelIsValidated = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_align(labelIsValidated, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 50);
+  lv_obj_align(labelIsValidated, labelVersion, LV_ALIGN_OUT_BOTTOM_LEFT, 0, 0);
   lv_label_set_recolor(labelIsValidated, true);
   lv_label_set_long_mode(labelIsValidated, LV_LABEL_LONG_BREAK);
   lv_obj_set_width(labelIsValidated, 240);

--- a/src/displayapp/screens/FirmwareValidation.cpp
+++ b/src/displayapp/screens/FirmwareValidation.cpp
@@ -17,12 +17,13 @@ namespace {
 FirmwareValidation::FirmwareValidation(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::FirmwareValidator& validator)
   : Screen {app}, validator {validator} {
   labelVersion = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_fmt(labelVersion, "Version : %d.%d.%d\n"
-                                      "ShortRef : %s",
-                                      Version::Major(),
-                                      Version::Minor(),
-                                      Version::Patch(),
-                                      Version::GitCommitHash());
+  lv_label_set_text_fmt(labelVersion,
+                        "Version : %d.%d.%d\n"
+                        "ShortRef : %s",
+                        Version::Major(),
+                        Version::Minor(),
+                        Version::Patch(),
+                        Version::GitCommitHash());
   lv_obj_align(labelVersion, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
 
   labelIsValidated = lv_label_create(lv_scr_act(), nullptr);

--- a/src/displayapp/screens/FirmwareValidation.h
+++ b/src/displayapp/screens/FirmwareValidation.h
@@ -23,12 +23,7 @@ namespace Pinetime {
       private:
         Pinetime::Controllers::FirmwareValidator& validator;
 
-        lv_obj_t* labelVersionInfo;
-        lv_obj_t* labelVersionValue;
-        lv_obj_t* labelShortRefInfo;
-        lv_obj_t* labelShortRefValue;
-        char version[9];
-        char shortref[9];
+        lv_obj_t* labelVersion;
         lv_obj_t* labelIsValidated;
         lv_obj_t* buttonValidate;
         lv_obj_t* labelButtonValidate;


### PR DESCRIPTION
Version and shortref info were spread out in four different labels. Here I combined them into a single label.