### PR TITLE
PineTimeStyle step gauge bugfix

### DIFF
--- a/src/displayapp/screens/PineTimeStyle.cpp
+++ b/src/displayapp/screens/PineTimeStyle.cpp
@@ -179,8 +179,8 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   lv_obj_align(stepGauge, sidebar, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
   lv_gauge_set_scale(stepGauge, 360, 11, 0);
   lv_gauge_set_angle_offset(stepGauge, 180);
-  lv_gauge_set_critical_value(stepGauge, (settingsController.GetStepsGoal() / 100));
-  lv_gauge_set_range(stepGauge, 0, (settingsController.GetStepsGoal() / 100));
+  lv_gauge_set_critical_value(stepGauge, 100);
+  lv_gauge_set_range(stepGauge, 0, 100);
   lv_gauge_set_value(stepGauge, 0, 0);
 
   lv_obj_set_style_local_pad_right(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 3);
@@ -328,7 +328,7 @@ bool PineTimeStyle::Refresh() {
   stepCount = motionController.NbSteps();
   motionSensorOk = motionController.IsSensorOk();
   if (stepCount.IsUpdated() || motionSensorOk.IsUpdated()) {
-    lv_gauge_set_value(stepGauge, 0, (stepCount.Get() / 100));
+    lv_gauge_set_value(stepGauge, 0, (stepCount.Get() / (settingsController.GetStepsGoal() / 100)));
     lv_obj_realign(stepGauge);
     if (stepCount.Get() > settingsController.GetStepsGoal()) {
       lv_obj_set_style_local_line_color(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);


### PR DESCRIPTION
The step gauge seems to have issues if the range is over 100, so this change sets the gauge range to 100 and calculates the step count as a percentage of the step goal to show progress.

Edit for a bit more context. Previously I was scaling the step gauge by adjusting the range, so a step goal of 13000 would make the range of the gauge 0-130, which resulted in only 9 divisions appearing. I'm not sure why this happened, but this fix changes the approach by setting the gauge range to 0-100 always, then calculating the needle position/progress as a percentage of the step goal.