### PR TITLE
Make firmware updating more foolproof

### DIFF
--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -266,13 +266,14 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
                          static_cast<uint8_t>(ErrorCodes::NoError)};
         notificationManager.AsyncSend(connectionHandle, controlPointCharacteristicHandle, data, 3);
       } else {
-        bleController.State(Pinetime::Controllers::Ble::FirmwareUpdateStates::Error);
         NRF_LOG_INFO("Image Error : bad CRC");
 
         uint8_t data[3] {static_cast<uint8_t>(Opcodes::Response),
                          static_cast<uint8_t>(Opcodes::ValidateFirmware),
                          static_cast<uint8_t>(ErrorCodes::CrcError)};
         notificationManager.AsyncSend(connectionHandle, controlPointCharacteristicHandle, data, 3);
+        bleController.State(Pinetime::Controllers::Ble::FirmwareUpdateStates::Error);
+        Reset();
       }
 
       return 0;
@@ -283,10 +284,8 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
         return 0;
       }
       NRF_LOG_INFO("[DFU] -> Activate image and reset!");
-      bleController.StopFirmwareUpdate();
-      systemTask.PushMessage(Pinetime::System::Messages::BleFirmwareUpdateFinished);
-      Reset();
       bleController.State(Pinetime::Controllers::Ble::FirmwareUpdateStates::Validated);
+      Reset();
       return 0;
     default:
       return 0;
@@ -294,6 +293,7 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
 }
 
 void DfuService::OnTimeout() {
+  bleController.State(Pinetime::Controllers::Ble::FirmwareUpdateStates::Error);
   Reset();
 }
 
@@ -307,7 +307,6 @@ void DfuService::Reset() {
   applicationSize = 0;
   expectedCrc = 0;
   notificationManager.Reset();
-  bleController.State(Pinetime::Controllers::Ble::FirmwareUpdateStates::Error);
   bleController.StopFirmwareUpdate();
   systemTask.PushMessage(Pinetime::System::Messages::BleFirmwareUpdateFinished);
 }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -180,9 +180,13 @@ void DisplayApp::Refresh() {
         }
         break;
       case Messages::TouchEvent: {
-        if (state != States::Running)
+        if (state != States::Running) {
           break;
+        }
         auto gesture = OnTouchEvent();
+        if (gesture == TouchEvents::None) {
+          break;
+        }
         if (!currentScreen->OnTouchEvent(gesture)) {
           if (currentApp == Apps::Clock) {
             switch (gesture) {

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -141,9 +141,6 @@ void DisplayApp::Refresh() {
   if (messageReceived) {
     switch (msg) {
       case Messages::GoToSleep:
-        if (bleController.IsFirmwareUpdating()) {
-          break;
-        }
         brightnessController.Backup();
         while (brightnessController.Level() != Controllers::BrightnessController::Levels::Off) {
           brightnessController.Lower();

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -132,6 +132,9 @@ void DisplayApp::Refresh() {
   if (xQueueReceive(msgQueue, &msg, queueTimeout)) {
     switch (msg) {
       case Messages::GoToSleep:
+        if (bleController.IsFirmwareUpdating()) {
+          break;
+        }
         brightnessController.Backup();
         while (brightnessController.Level() != Controllers::BrightnessController::Levels::Off) {
           brightnessController.Lower();
@@ -277,6 +280,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       break;
     case Apps::FirmwareUpdate:
       currentScreen = std::make_unique<Screens::FirmwareUpdate>(this, bleController);
+      ReturnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::None);
       break;
 
     case Apps::Notifications:

--- a/src/displayapp/screens/FirmwareUpdate.cpp
+++ b/src/displayapp/screens/FirmwareUpdate.cpp
@@ -5,21 +5,6 @@
 
 using namespace Pinetime::Applications::Screens;
 
-namespace {
-  // Copied from StopWatch.cpp
-  TickType_t calculateDelta(const TickType_t startTime, const TickType_t currentTime) {
-    TickType_t delta = 0;
-    // Take care of overflow
-    if (startTime > currentTime) {
-      delta = 0xffffffff - startTime;
-      delta += (currentTime + 1);
-    } else {
-      delta = currentTime - startTime;
-    }
-    return delta;
-  }
-}
-
 FirmwareUpdate::FirmwareUpdate(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Ble& bleController)
   : Screen(app), bleController {bleController} {
 
@@ -59,11 +44,11 @@ bool FirmwareUpdate::Refresh() {
       // This condition makes sure that the app is exited if somehow it got
       // launched without a firmware update. This should never happen.
       if (state != States::Error) {
-        if (calculateDelta(startTime, xTaskGetTickCount()) > (60 * 1024)) {
+        if (xTaskGetTickCount() - startTime > (60 * 1024)) {
           UpdateError();
           state = States::Error;
         }
-      } else if (calculateDelta(startTime, xTaskGetTickCount()) > (5 * 1024)) {
+      } else if (xTaskGetTickCount() - startTime > (5 * 1024)) {
         running = false;
       }
       break;
@@ -83,7 +68,7 @@ bool FirmwareUpdate::Refresh() {
         UpdateError();
         state = States::Error;
       }
-      if (calculateDelta(startTime, xTaskGetTickCount()) > (5 * 1024)) {
+      if (xTaskGetTickCount() - startTime > (5 * 1024)) {
         running = false;
       }
       break;

--- a/src/displayapp/screens/FirmwareUpdate.h
+++ b/src/displayapp/screens/FirmwareUpdate.h
@@ -25,13 +25,17 @@ namespace Pinetime {
         lv_obj_t* titleLabel;
         mutable char percentStr[10];
 
-        States state;
+        States state = States::Idle;
 
-        bool DisplayProgression() const;
+        void DisplayProgression() const;
+
+        bool OnButtonPushed() override;
 
         void UpdateValidated();
 
         void UpdateError();
+
+        uint32_t startTime;
       };
     }
   }

--- a/src/displayapp/screens/FirmwareUpdate.h
+++ b/src/displayapp/screens/FirmwareUpdate.h
@@ -2,6 +2,7 @@
 
 #include "Screen.h"
 #include <lvgl/src/lv_core/lv_obj.h>
+#include "FreeRTOS.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -35,7 +36,7 @@ namespace Pinetime {
 
         void UpdateError();
 
-        uint32_t startTime;
+        TickType_t startTime;
       };
     }
   }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -270,10 +270,11 @@ void SystemTask::Work() {
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::BleFirmwareUpdateStarted);
           break;
         case Messages::BleFirmwareUpdateFinished:
+          if (bleController.State() == Pinetime::Controllers::Ble::FirmwareUpdateStates::Validated) {
+            NVIC_SystemReset();
+          }
           doNotGoToSleep = false;
           xTimerStart(idleTimer, 0);
-          if (bleController.State() == Pinetime::Controllers::Ble::FirmwareUpdateStates::Validated)
-            NVIC_SystemReset();
           break;
         case Messages::OnTouchEvent:
           ReloadIdleTimer();

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -198,7 +198,11 @@ void SystemTask::Work() {
       Messages message = static_cast<Messages>(msg);
       switch (message) {
         case Messages::EnableSleeping:
-          doNotGoToSleep = false;
+          // Make sure that exiting an app doesn't enable sleeping,
+          // if the exiting was caused by a firmware update
+          if (!bleController.IsFirmwareUpdating()) {
+            doNotGoToSleep = false;
+          }
           break;
         case Messages::DisableSleeping:
           doNotGoToSleep = true;


### PR DESCRIPTION
Made the firmware update screen not exitable by the user. The screen closes automatically if an error occurs.
Added precautions to make sure the device doesn't sleep during firmware update.
Fixed bugs like State not resetting on error, and BleFirmwareUpdateFinished message being pushed before the Validated state was set.
Fixes #316 