### PR TITLE
LVGL use system tick

### DIFF
--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -77,7 +77,7 @@
 #define configENABLE_BACKWARD_COMPATIBILITY     1
 
 /* Hook function related definitions. */
-#define configUSE_IDLE_HOOK            1
+#define configUSE_IDLE_HOOK            0
 #define configUSE_TICK_HOOK            0
 #define configCHECK_FOR_STACK_OVERFLOW 0
 #define configUSE_MALLOC_FAILED_HOOK   0

--- a/src/displayapp/screens/BatteryInfo.cpp
+++ b/src/displayapp/screens/BatteryInfo.cpp
@@ -9,11 +9,6 @@ static void lv_update_task(struct _lv_task_t* task) {
   user_data->UpdateScreen();
 }
 
-static void lv_anim_task(struct _lv_task_t* task) {
-  auto user_data = static_cast<BatteryInfo*>(task->user_data);
-  user_data->UpdateAnim();
-}
-
 BatteryInfo::BatteryInfo(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Battery& batteryController)
   : Screen(app), batteryController {batteryController} {
 
@@ -24,12 +19,12 @@ BatteryInfo::BatteryInfo(Pinetime::Applications::DisplayApp* app, Pinetime::Cont
   lv_obj_set_size(charging_bar, 200, 15);
   lv_bar_set_range(charging_bar, 0, 100);
   lv_obj_align(charging_bar, nullptr, LV_ALIGN_CENTER, 0, 10);
-  lv_bar_set_anim_time(charging_bar, 2000);
+  lv_bar_set_anim_time(charging_bar, 1000);
   lv_obj_set_style_local_radius(charging_bar, LV_BAR_PART_BG, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
   lv_obj_set_style_local_bg_color(charging_bar, LV_BAR_PART_BG, LV_STATE_DEFAULT, lv_color_hex(0x222222));
   lv_obj_set_style_local_bg_opa(charging_bar, LV_BAR_PART_BG, LV_STATE_DEFAULT, LV_OPA_100);
   lv_obj_set_style_local_bg_color(charging_bar, LV_BAR_PART_INDIC, LV_STATE_DEFAULT, lv_color_hex(0xFF0000));
-  lv_bar_set_value(charging_bar, batteryPercent, LV_ANIM_OFF);
+  lv_bar_set_value(charging_bar, batteryPercent, LV_ANIM_ON);
 
   status = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(status, "Reading Battery status");
@@ -58,38 +53,13 @@ BatteryInfo::BatteryInfo(Pinetime::Applications::DisplayApp* app, Pinetime::Cont
   lv_obj_set_pos(backgroundLabel, 0, 0);
   lv_label_set_text_static(backgroundLabel, "");
 
-  taskUpdate = lv_task_create(lv_update_task, 500000, LV_TASK_PRIO_LOW, this);
-  taskAnim = lv_task_create(lv_anim_task, 1000, LV_TASK_PRIO_LOW, this);
+  taskUpdate = lv_task_create(lv_update_task, 5000, LV_TASK_PRIO_LOW, this);
   UpdateScreen();
 }
 
 BatteryInfo::~BatteryInfo() {
   lv_task_del(taskUpdate);
-  lv_task_del(taskAnim);
   lv_obj_clean(lv_scr_act());
-}
-
-void BatteryInfo::UpdateAnim() {
-  batteryPercent = batteryController.PercentRemaining();
-
-  if (batteryPercent >= 0) {
-    if (batteryController.IsCharging() and batteryPercent < 100) {
-      animation += 1;
-      if (animation >= 100) {
-        animation = 0;
-      }
-
-    } else {
-      if (animation > batteryPercent) {
-        animation--;
-      }
-      if (animation < batteryPercent) {
-        animation++;
-      }
-    }
-
-    lv_bar_set_value(charging_bar, animation, LV_ANIM_OFF);
-  }
 }
 
 void BatteryInfo::UpdateScreen() {
@@ -123,9 +93,9 @@ void BatteryInfo::UpdateScreen() {
 
   lv_obj_align(status, charging_bar, LV_ALIGN_OUT_BOTTOM_MID, 0, 20);
   lv_label_set_text_fmt(voltage, "%1i.%02i volts", batteryVoltage / 1000, batteryVoltage % 1000 / 10);
+  lv_bar_set_value(charging_bar, batteryPercent, LV_ANIM_ON);
 }
 
 bool BatteryInfo::Refresh() {
-
   return running;
 }

--- a/src/displayapp/screens/BatteryInfo.h
+++ b/src/displayapp/screens/BatteryInfo.h
@@ -22,7 +22,6 @@ namespace Pinetime {
         bool Refresh() override;
 
         void UpdateScreen();
-        void UpdateAnim();
 
       private:
         Pinetime::Controllers::Battery& batteryController;
@@ -33,9 +32,7 @@ namespace Pinetime {
         lv_obj_t* status;
 
         lv_task_t* taskUpdate;
-        lv_task_t* taskAnim;
 
-        int8_t animation = 0;
         int8_t batteryPercent = -1;
         uint16_t batteryVoltage = 0;
       };

--- a/src/displayapp/screens/Tile.cpp
+++ b/src/displayapp/screens/Tile.cpp
@@ -107,7 +107,7 @@ Tile::Tile(uint8_t screenID,
   lv_obj_set_pos(backgroundLabel, 0, 0);
   lv_label_set_text_static(backgroundLabel, "");
 
-  taskUpdate = lv_task_create(lv_update_task, 500000, LV_TASK_PRIO_MID, this);
+  taskUpdate = lv_task_create(lv_update_task, 5000, LV_TASK_PRIO_MID, this);
 }
 
 Tile::~Tile() {

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -110,7 +110,7 @@ QuickSettings::QuickSettings(Pinetime::Applications::DisplayApp* app,
   lv_obj_set_pos(backgroundLabel, 0, 0);
   lv_label_set_text_static(backgroundLabel, "");
 
-  taskUpdate = lv_task_create(lv_update_task, 500000, LV_TASK_PRIO_MID, this);
+  taskUpdate = lv_task_create(lv_update_task, 5000, LV_TASK_PRIO_MID, this);
 }
 
 QuickSettings::~QuickSettings() {

--- a/src/libs/lv_conf.h
+++ b/src/libs/lv_conf.h
@@ -293,10 +293,10 @@ typedef void* lv_img_decoder_user_data_t;
 
 /* 1: use a custom tick source.
  * It removes the need to manually update the tick with `lv_tick_inc`) */
-#define LV_TICK_CUSTOM     0
+#define LV_TICK_CUSTOM     1
 #if LV_TICK_CUSTOM == 1
-#define LV_TICK_CUSTOM_INCLUDE  "Arduino.h"         /*Header for the system time function*/
-#define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())     /*Expression evaluating to current system time in ms*/
+#define LV_TICK_CUSTOM_INCLUDE  "FreeRTOS.h"       /*Header for the system time function*/
+#define LV_TICK_CUSTOM_SYS_TIME_EXPR (xTaskGetTickCount()) /*Expression evaluating to current system time in ms*/
 #endif   /*LV_TICK_CUSTOM*/
 
 typedef void* lv_disp_drv_user_data_t;             /*Type of user data in the display driver*/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,13 +175,6 @@ void nrfx_gpiote_evt_handler(nrfx_gpiote_pin_t pin, nrf_gpiote_polarity_t action
   portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 }
 
-extern "C" {
-void vApplicationIdleHook(void) {
-  if (!isFactory)
-    lv_tick_inc(1);
-}
-}
-
 void DebounceTimerChargeCallback(TimerHandle_t xTimer) {
   xTimerStop(xTimer, 0);
   systemTask.PushMessage(Pinetime::System::Messages::OnChargingEvent);


### PR DESCRIPTION
Instead of ticking a separate lvgl counter, let LVGL use the system time.
For every 1000ms lvgl thinks 1024ms have passed, which is close enough, and much closer than before.

Fixes #435 and #306?