### PR TITLE
Set date and time manually

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -420,6 +420,8 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/SettingWakeUp.cpp
         displayapp/screens/settings/SettingDisplay.cpp
         displayapp/screens/settings/SettingSteps.cpp
+        displayapp/screens/settings/SettingSetDate.cpp
+        displayapp/screens/settings/SettingSetTime.cpp
 
         ## Watch faces
         displayapp/icons/bg_clock.c

--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -30,7 +30,9 @@ namespace Pinetime {
       SettingTimeFormat,
       SettingDisplay,
       SettingWakeUp,
-      SettingSteps
+      SettingSteps,
+      SettingSetDate,
+      SettingSetTime
     };
   }
 }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -42,6 +42,8 @@
 #include "displayapp/screens/settings/SettingWakeUp.h"
 #include "displayapp/screens/settings/SettingDisplay.h"
 #include "displayapp/screens/settings/SettingSteps.h"
+#include "displayapp/screens/settings/SettingSetDate.h"
+#include "displayapp/screens/settings/SettingSetTime.h"
 
 using namespace Pinetime::Applications;
 using namespace Pinetime::Applications::Display;
@@ -321,6 +323,14 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       break;
     case Apps::SettingSteps:
       currentScreen = std::make_unique<Screens::SettingSteps>(this, settingsController);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      break;
+    case Apps::SettingSetDate:
+      currentScreen = std::make_unique<Screens::SettingSetDate>(this, dateTimeController);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      break;
+    case Apps::SettingSetTime:
+      currentScreen = std::make_unique<Screens::SettingSetTime>(this, dateTimeController);
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::BatteryInfo:

--- a/src/displayapp/screens/settings/SettingSetDate.cpp
+++ b/src/displayapp/screens/settings/SettingSetDate.cpp
@@ -1,0 +1,272 @@
+#include "SettingSetDate.h"
+#include <lvgl/lvgl.h>
+#include <hal/nrf_rtc.h>
+#include <nrf_log.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Symbols.h"
+
+#define POS_X_DAY   -72
+#define POS_X_MONTH   0
+#define POS_X_YEAR   72
+#define POS_Y_PLUS  -50
+#define POS_Y_TEXT   -6
+#define POS_Y_MINUS  40
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  static void event_handler(lv_obj_t * obj, lv_event_t event) {
+    SettingSetDate* screen = static_cast<SettingSetDate *>(obj->user_data);
+    screen->HandleButtonPress(obj, event);
+  }
+}
+
+SettingSetDate::SettingSetDate(
+  Pinetime::Applications::DisplayApp *app, Pinetime::Controllers::DateTime &dateTimeController) :
+  Screen(app),
+  dateTimeController {dateTimeController}
+{
+
+  lv_obj_t * container1 = lv_cont_create(lv_scr_act(), nullptr);
+
+  //lv_obj_set_style_local_bg_color(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x111111));
+  lv_obj_set_style_local_bg_opa(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
+  lv_obj_set_style_local_pad_all(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
+  lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_pos(container1, 30, 60);
+  lv_obj_set_width(container1, LV_HOR_RES - 50);
+  lv_obj_set_height(container1, LV_VER_RES - 60);
+  lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
+
+  lv_obj_t * title = lv_label_create(lv_scr_act(), NULL);  
+  lv_label_set_text_static(title, "Set current date");
+  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 15, 15);
+
+  lv_obj_t * icon = lv_label_create(lv_scr_act(), NULL);
+  lv_obj_set_style_local_text_color(icon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
+  
+  lv_label_set_text_static(icon, Symbols::clock);
+  lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
+
+  dayValue = static_cast<int>(dateTimeController.Day());
+  lblDay = lv_label_create(lv_scr_act(), NULL);
+  //lv_obj_set_style_local_text_font(lblDay, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_fmt(lblDay, "%d", dayValue);
+  lv_label_set_align(lblDay, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(lblDay, lv_scr_act(), LV_ALIGN_CENTER, POS_X_DAY, POS_Y_TEXT);
+
+  monthValue = static_cast<int>(dateTimeController.Month());
+  lblMonth = lv_label_create(lv_scr_act(), NULL);
+  //lv_obj_set_style_local_text_font(lblMonth, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  UpdateMonthLabel();
+
+  yearValue = static_cast<int>(dateTimeController.Year());
+  if (yearValue < 2021)
+    yearValue = 2021;
+  lblYear = lv_label_create(lv_scr_act(), NULL);
+  //lv_obj_set_style_local_text_font(lblYear, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_fmt(lblYear, "%d", yearValue);
+  lv_label_set_align(lblYear, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(lblYear, lv_scr_act(), LV_ALIGN_CENTER, POS_X_YEAR, POS_Y_TEXT);
+
+  btnDayPlus = lv_btn_create(lv_scr_act(), NULL);
+  btnDayPlus->user_data = this;
+  lv_obj_set_size(btnDayPlus, 50, 40);
+  lv_obj_align(btnDayPlus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_DAY, POS_Y_PLUS);
+  lv_obj_set_style_local_value_str(btnDayPlus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
+  lv_obj_set_event_cb(btnDayPlus, event_handler);
+
+  btnDayMinus = lv_btn_create(lv_scr_act(), NULL);
+  btnDayMinus->user_data = this;
+  lv_obj_set_size(btnDayMinus, 50, 40);
+  lv_obj_align(btnDayMinus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_DAY, POS_Y_MINUS);
+  lv_obj_set_style_local_value_str(btnDayMinus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
+  lv_obj_set_event_cb(btnDayMinus, event_handler);
+
+  btnMonthPlus = lv_btn_create(lv_scr_act(), NULL);
+  btnMonthPlus->user_data = this;
+  lv_obj_set_size(btnMonthPlus, 50, 40);
+  lv_obj_align(btnMonthPlus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_MONTH, POS_Y_PLUS);
+  lv_obj_set_style_local_value_str(btnMonthPlus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
+  lv_obj_set_event_cb(btnMonthPlus, event_handler);
+
+  btnMonthMinus = lv_btn_create(lv_scr_act(), NULL);
+  btnMonthMinus->user_data = this;
+  lv_obj_set_size(btnMonthMinus, 50, 40);
+  lv_obj_align(btnMonthMinus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_MONTH, POS_Y_MINUS);
+  lv_obj_set_style_local_value_str(btnMonthMinus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
+  lv_obj_set_event_cb(btnMonthMinus, event_handler);
+
+  btnYearPlus = lv_btn_create(lv_scr_act(), NULL);
+  btnYearPlus->user_data = this;
+  lv_obj_set_size(btnYearPlus, 50, 40);
+  lv_obj_align(btnYearPlus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_YEAR, POS_Y_PLUS);
+  lv_obj_set_style_local_value_str(btnYearPlus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
+  lv_obj_set_event_cb(btnYearPlus, event_handler);
+
+  btnYearMinus = lv_btn_create(lv_scr_act(), NULL);
+  btnYearMinus->user_data = this;
+  lv_obj_set_size(btnYearMinus, 50, 40);
+  lv_obj_align(btnYearMinus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_YEAR, POS_Y_MINUS);
+  lv_obj_set_style_local_value_str(btnYearMinus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
+  lv_obj_set_event_cb(btnYearMinus, event_handler);
+
+  btnSetTime = lv_btn_create(lv_scr_act(), NULL);
+  btnSetTime->user_data = this;
+  lv_obj_set_size(btnSetTime, 70, 40);
+  lv_obj_align(btnSetTime, lv_scr_act(), LV_ALIGN_CENTER, 0, 90);
+  lv_obj_set_style_local_value_str(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Set");
+  lv_obj_set_event_cb(btnSetTime, event_handler);
+}
+
+SettingSetDate::~SettingSetDate() {
+  lv_obj_clean(lv_scr_act());
+}
+
+bool SettingSetDate::Refresh() {
+  return running;
+}
+
+
+void SettingSetDate::HandleButtonPress(lv_obj_t *object, lv_event_t event) {
+
+  if(object == btnDayPlus && (event == LV_EVENT_PRESSED)) {
+    dayValue++;
+    if (dayValue > MaximumDayOfMonth())
+      dayValue = 1;
+    lv_label_set_text_fmt(lblDay, "%d", dayValue);
+    lv_obj_align(lblDay, lv_scr_act(), LV_ALIGN_CENTER, POS_X_DAY, POS_Y_TEXT);
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+  }
+
+  if(object == btnDayMinus && (event == LV_EVENT_PRESSED)) {
+    dayValue--;
+    if (dayValue < 1)
+      dayValue = MaximumDayOfMonth();
+    lv_label_set_text_fmt(lblDay, "%d", dayValue);
+    lv_obj_align(lblDay, lv_scr_act(), LV_ALIGN_CENTER, POS_X_DAY, POS_Y_TEXT);
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+  }
+
+  if(object == btnMonthPlus && (event == LV_EVENT_PRESSED)) {
+    monthValue++;
+    if (monthValue > 12)
+      monthValue = 1;
+    UpdateMonthLabel();
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+    CheckDay();
+  }
+
+  if(object == btnMonthMinus && (event == LV_EVENT_PRESSED)) {
+    monthValue--;
+    if (monthValue < 1)
+      monthValue = 12;
+    UpdateMonthLabel();
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+    CheckDay();
+  }
+
+  if(object == btnYearPlus && (event == LV_EVENT_PRESSED)) {
+    yearValue++;
+    lv_label_set_text_fmt(lblYear, "%d", yearValue);
+    lv_obj_align(lblYear, lv_scr_act(), LV_ALIGN_CENTER, POS_X_YEAR, POS_Y_TEXT);
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+    CheckDay();
+  }
+
+  if(object == btnYearMinus && (event == LV_EVENT_PRESSED)) {
+    yearValue--;
+    lv_label_set_text_fmt(lblYear, "%d", yearValue);
+    lv_obj_align(lblYear, lv_scr_act(), LV_ALIGN_CENTER, POS_X_YEAR, POS_Y_TEXT);
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+    CheckDay();
+  }
+
+  if(object == btnSetTime && (event == LV_EVENT_PRESSED)) {
+    NRF_LOG_INFO("Setting date (manually) to %04d-%02d-%02d", yearValue, monthValue, dayValue);
+    dateTimeController.SetTime(static_cast<uint16_t>(yearValue),
+                               static_cast<uint8_t>(monthValue),
+                               static_cast<uint8_t>(dayValue),
+                               0,
+                               dateTimeController.Hours(),
+                               dateTimeController.Minutes(),
+                               dateTimeController.Seconds(),
+                               nrf_rtc_counter_get(portNRF_RTC_REG));
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_DISABLED);
+  }
+}
+
+int SettingSetDate::MaximumDayOfMonth() const {
+  switch (monthValue) {
+    case 2:
+      if ((((yearValue % 4) == 0) && ((yearValue % 100) != 0)) || ((yearValue % 400) == 0))
+        return 29;
+      return 28;
+    case 4:
+    case 6:
+    case 9:
+    case 11:
+      return 30;
+    default:
+      return 31;
+  }
+}
+
+void SettingSetDate::CheckDay() {
+  int maxDay = MaximumDayOfMonth();
+  if (dayValue > maxDay) {
+    dayValue = maxDay;
+    lv_label_set_text_fmt(lblDay, "%d", dayValue);
+    lv_obj_align(lblDay, lv_scr_act(), LV_ALIGN_CENTER, POS_X_DAY, POS_Y_TEXT);
+  }
+}
+
+void SettingSetDate::UpdateMonthLabel() {
+  switch (monthValue) {
+    case 1:
+      lv_label_set_text_static(lblMonth, "Jan");
+      break;
+    case 2:
+      lv_label_set_text_static(lblMonth, "Feb");
+      break;
+    case 3:
+      lv_label_set_text_static(lblMonth, "Mar");
+      break;
+    case 4:
+      lv_label_set_text_static(lblMonth, "Apr");
+      break;
+    case 5:
+      lv_label_set_text_static(lblMonth, "May");
+      break;
+    case 6:
+      lv_label_set_text_static(lblMonth, "Jun");
+      break;
+    case 7:
+      lv_label_set_text_static(lblMonth, "Jul");
+      break;
+    case 8:
+      lv_label_set_text_static(lblMonth, "Aug");
+      break;
+    case 9:
+      lv_label_set_text_static(lblMonth, "Sep");
+      break;
+    case 10:
+      lv_label_set_text_static(lblMonth, "Oct");
+      break;
+    case 11:
+      lv_label_set_text_static(lblMonth, "Nov");
+      break;
+    case 12:
+      lv_label_set_text_static(lblMonth, "Dec");
+      break;
+    default:
+      lv_label_set_text_static(lblMonth, "---");
+      break;
+  }
+  lv_label_set_align(lblMonth, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(lblMonth, lv_scr_act(), LV_ALIGN_CENTER, POS_X_MONTH, POS_Y_TEXT);
+}
+

--- a/src/displayapp/screens/settings/SettingSetDate.h
+++ b/src/displayapp/screens/settings/SettingSetDate.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstdint>
+#include <lvgl/lvgl.h>
+#include "components/datetime/DateTimeController.h"
+#include "displayapp/screens/Screen.h"
+
+namespace Pinetime {
+
+  namespace Applications {
+    namespace Screens {
+
+      class SettingSetDate : public Screen{
+        public:
+          SettingSetDate(DisplayApp* app, Pinetime::Controllers::DateTime &dateTimeController);
+          ~SettingSetDate() override;
+
+          bool Refresh() override;
+          void HandleButtonPress(lv_obj_t *object, lv_event_t event);
+         
+        private:          
+
+          Controllers::DateTime& dateTimeController;
+
+          int dayValue;
+          int monthValue;
+          int yearValue;
+          lv_obj_t * lblDay;
+          lv_obj_t * lblMonth;
+          lv_obj_t * lblYear;
+          lv_obj_t * btnDayPlus;
+          lv_obj_t * btnDayMinus;
+          lv_obj_t * btnMonthPlus;
+          lv_obj_t * btnMonthMinus;
+          lv_obj_t * btnYearPlus;
+          lv_obj_t * btnYearMinus;
+          lv_obj_t * btnSetTime;
+
+          int MaximumDayOfMonth() const;
+          void CheckDay();
+          void UpdateMonthLabel();
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingSetTime.cpp
+++ b/src/displayapp/screens/settings/SettingSetTime.cpp
@@ -1,0 +1,174 @@
+#include "SettingSetTime.h"
+#include <lvgl/lvgl.h>
+#include <hal/nrf_rtc.h>
+#include <nrf_log.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  static void event_handler(lv_obj_t * obj, lv_event_t event) {
+    SettingSetTime* screen = static_cast<SettingSetTime *>(obj->user_data);
+    screen->HandleButtonPress(obj, event);
+  }
+}
+
+SettingSetTime::SettingSetTime(
+  Pinetime::Applications::DisplayApp *app, Pinetime::Controllers::DateTime &dateTimeController) :
+  Screen(app),
+  dateTimeController {dateTimeController}
+{
+
+  lv_obj_t * container1 = lv_cont_create(lv_scr_act(), nullptr);
+
+  //lv_obj_set_style_local_bg_color(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x111111));
+  lv_obj_set_style_local_bg_opa(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
+  lv_obj_set_style_local_pad_all(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
+  lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_pos(container1, 30, 60);
+  lv_obj_set_width(container1, LV_HOR_RES - 50);
+  lv_obj_set_height(container1, LV_VER_RES - 60);
+  lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
+
+  lv_obj_t * title = lv_label_create(lv_scr_act(), NULL);  
+  lv_label_set_text_static(title, "Set current time");
+  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 15, 15);
+
+  lv_obj_t * icon = lv_label_create(lv_scr_act(), NULL);
+  lv_obj_set_style_local_text_color(icon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
+  
+  lv_label_set_text_static(icon, Symbols::clock);
+  lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
+
+  hoursValue = static_cast<int>(dateTimeController.Hours());
+  lblHours = lv_label_create(lv_scr_act(), NULL);
+  lv_obj_set_style_local_text_font(lblHours, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_fmt(lblHours, "%02d", hoursValue);
+  lv_label_set_align(lblHours, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(lblHours, lv_scr_act(), LV_ALIGN_CENTER, -72, -6);
+
+  lv_obj_t * lblColon1 = lv_label_create(lv_scr_act(), NULL);
+  lv_obj_set_style_local_text_font(lblColon1, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_static(lblColon1, ":");
+  lv_label_set_align(lblColon1, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(lblColon1, lv_scr_act(), LV_ALIGN_CENTER, -36, -8);
+
+  minutesValue = static_cast<int>(dateTimeController.Minutes());
+  lblMinutes = lv_label_create(lv_scr_act(), NULL);
+  lv_obj_set_style_local_text_font(lblMinutes, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_fmt(lblMinutes, "%02d", minutesValue);
+  lv_label_set_align(lblMinutes, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(lblMinutes, lv_scr_act(), LV_ALIGN_CENTER, 0, -6);
+
+  lv_obj_t * lblColon2 = lv_label_create(lv_scr_act(), NULL);
+  lv_obj_set_style_local_text_font(lblColon2, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_static(lblColon2, ":");
+  lv_label_set_align(lblColon2, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(lblColon2, lv_scr_act(), LV_ALIGN_CENTER, 36, -8);
+
+  lv_obj_t * lblSeconds = lv_label_create(lv_scr_act(), NULL);
+  lv_obj_set_style_local_text_font(lblSeconds, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_static(lblSeconds, "00");
+  lv_label_set_align(lblSeconds, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(lblSeconds, lv_scr_act(), LV_ALIGN_CENTER, 72, -6);
+
+  btnHoursPlus = lv_btn_create(lv_scr_act(), NULL);
+  btnHoursPlus->user_data = this;
+  lv_obj_set_size(btnHoursPlus, 50, 40);
+  lv_obj_align(btnHoursPlus, lv_scr_act(), LV_ALIGN_CENTER, -72, -50);
+  lv_obj_set_style_local_value_str(btnHoursPlus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
+  lv_obj_set_event_cb(btnHoursPlus, event_handler);
+
+  btnHoursMinus = lv_btn_create(lv_scr_act(), NULL);
+  btnHoursMinus->user_data = this;
+  lv_obj_set_size(btnHoursMinus, 50, 40);
+  lv_obj_align(btnHoursMinus, lv_scr_act(), LV_ALIGN_CENTER, -72, 40);
+  lv_obj_set_style_local_value_str(btnHoursMinus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
+  lv_obj_set_event_cb(btnHoursMinus, event_handler);
+
+  btnMinutesPlus = lv_btn_create(lv_scr_act(), NULL);
+  btnMinutesPlus->user_data = this;
+  lv_obj_set_size(btnMinutesPlus, 50, 40);
+  lv_obj_align(btnMinutesPlus, lv_scr_act(), LV_ALIGN_CENTER, 0, -50);
+  lv_obj_set_style_local_value_str(btnMinutesPlus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
+  lv_obj_set_event_cb(btnMinutesPlus, event_handler);
+
+  btnMinutesMinus = lv_btn_create(lv_scr_act(), NULL);
+  btnMinutesMinus->user_data = this;
+  lv_obj_set_size(btnMinutesMinus, 50, 40);
+  lv_obj_align(btnMinutesMinus, lv_scr_act(), LV_ALIGN_CENTER, 0, 40);
+  lv_obj_set_style_local_value_str(btnMinutesMinus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
+  lv_obj_set_event_cb(btnMinutesMinus, event_handler);
+
+  btnSetTime = lv_btn_create(lv_scr_act(), NULL);
+  btnSetTime->user_data = this;
+  lv_obj_set_size(btnSetTime, 70, 40);
+  lv_obj_align(btnSetTime, lv_scr_act(), LV_ALIGN_CENTER, 0, 90);
+  lv_obj_set_style_local_value_str(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Set");
+  lv_obj_set_event_cb(btnSetTime, event_handler);
+}
+
+SettingSetTime::~SettingSetTime() {
+  lv_obj_clean(lv_scr_act());
+}
+
+bool SettingSetTime::Refresh() {
+  return running;
+}
+
+
+void SettingSetTime::HandleButtonPress(lv_obj_t *object, lv_event_t event) {
+
+  if(object == btnHoursPlus && (event == LV_EVENT_PRESSED)) {
+    hoursValue++;
+    if (hoursValue > 23)
+      hoursValue = 0;
+    lv_label_set_text_fmt(lblHours, "%02d", hoursValue);
+    lv_obj_align(lblHours, lv_scr_act(), LV_ALIGN_CENTER, -72, -6);
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+  }
+
+  if(object == btnHoursMinus && (event == LV_EVENT_PRESSED)) {
+    hoursValue--;
+    if (hoursValue < 0)
+      hoursValue = 23;
+    lv_label_set_text_fmt(lblHours, "%02d", hoursValue);
+    lv_obj_align(lblHours, lv_scr_act(), LV_ALIGN_CENTER, -72, -6);
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+  }
+
+  if(object == btnMinutesPlus && (event == LV_EVENT_PRESSED)) {
+    minutesValue++;
+    if (minutesValue > 59)
+      minutesValue = 0;
+    lv_label_set_text_fmt(lblMinutes, "%02d", minutesValue);
+    lv_obj_align(lblMinutes, lv_scr_act(), LV_ALIGN_CENTER, 0, -6);
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+  }
+
+  if(object == btnMinutesMinus && (event == LV_EVENT_PRESSED)) {
+    minutesValue--;
+    if (minutesValue < 0)
+      minutesValue = 59;
+    lv_label_set_text_fmt(lblMinutes, "%02d", minutesValue);
+    lv_obj_align(lblMinutes, lv_scr_act(), LV_ALIGN_CENTER, 0, -6);
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+  }
+
+  if(object == btnSetTime && (event == LV_EVENT_PRESSED)) {
+    NRF_LOG_INFO("Setting time (manually) to %02d:%02d:00", hoursValue, minutesValue);
+    dateTimeController.SetTime(dateTimeController.Year(),
+                               static_cast<uint8_t>(dateTimeController.Month()),
+                               dateTimeController.Day(),
+                               static_cast<uint8_t>(dateTimeController.DayOfWeek()),
+                               static_cast<uint8_t>(hoursValue),
+                               static_cast<uint8_t>(minutesValue),
+                               0,
+                               nrf_rtc_counter_get(portNRF_RTC_REG));
+    lv_btn_set_state(btnSetTime, LV_BTN_STATE_DISABLED);
+  }
+}

--- a/src/displayapp/screens/settings/SettingSetTime.h
+++ b/src/displayapp/screens/settings/SettingSetTime.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <lvgl/lvgl.h>
+#include "components/datetime/DateTimeController.h"
+#include "displayapp/screens/Screen.h"
+
+namespace Pinetime {
+
+  namespace Applications {
+    namespace Screens {
+
+      class SettingSetTime : public Screen{
+        public:
+          SettingSetTime(DisplayApp* app, Pinetime::Controllers::DateTime &dateTimeController);
+          ~SettingSetTime() override;
+
+          bool Refresh() override;
+          void HandleButtonPress(lv_obj_t *object, lv_event_t event);
+         
+        private:          
+
+          Controllers::DateTime& dateTimeController;
+
+          int hoursValue;
+          int minutesValue;
+          lv_obj_t * lblHours;
+          lv_obj_t * lblMinutes;
+          lv_obj_t * btnHoursPlus;
+          lv_obj_t * btnHoursMinus;
+          lv_obj_t * btnMinutesPlus;
+          lv_obj_t * btnMinutesMinus;
+          lv_obj_t * btnSetTime;
+          
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -18,6 +18,9 @@ Settings::Settings(Pinetime::Applications::DisplayApp* app, Pinetime::Controller
               },
               [this]() -> std::unique_ptr<Screen> {
                 return CreateScreen2();
+              },
+              [this]() -> std::unique_ptr<Screen> {
+                return CreateScreen3();
               }},
              Screens::ScreenListModes::UpDown} {
 }
@@ -46,7 +49,7 @@ std::unique_ptr<Screen> Settings::CreateScreen1() {
     {Symbols::clock, "Watch face", Apps::SettingWatchFace},
   }};
 
-  return std::make_unique<Screens::List>(0, 2, app, settingsController, applications);
+  return std::make_unique<Screens::List>(0, 3, app, settingsController, applications);
 }
 
 std::unique_ptr<Screen> Settings::CreateScreen2() {
@@ -58,5 +61,15 @@ std::unique_ptr<Screen> Settings::CreateScreen2() {
     {Symbols::list, "About", Apps::SysInfo},
   }};
 
-  return std::make_unique<Screens::List>(1, 2, app, settingsController, applications);
+  return std::make_unique<Screens::List>(1, 3, app, settingsController, applications);
+}
+
+std::unique_ptr<Screen> Settings::CreateScreen3() {
+
+  std::array<Screens::List::Applications, 4> applications {{
+    {Symbols::clock, "Set date", Apps::SettingSetDate},
+    {Symbols::clock, "Set time", Apps::SettingSetTime},
+  }};
+
+  return std::make_unique<Screens::List>(2, 3, app, settingsController, applications);
 }

--- a/src/displayapp/screens/settings/Settings.h
+++ b/src/displayapp/screens/settings/Settings.h
@@ -21,10 +21,11 @@ namespace Pinetime {
       private:
         Controllers::Settings& settingsController;
 
-        ScreenList<2> screens;
+        ScreenList<3> screens;
 
         std::unique_ptr<Screen> CreateScreen1();
         std::unique_ptr<Screen> CreateScreen2();
+        std::unique_ptr<Screen> CreateScreen3();
       };
     }
   }


### PR DESCRIPTION
This PR adds two screens for setting date and time manually (solution for issue #364).

The screens are accessible through a third Settings page:
![datetime-settings](https://user-images.githubusercontent.com/11667344/125080548-39554200-e0c5-11eb-832c-4280977cd187.jpg)

Here's how the time is set:
You set the hours and the minutes, wait until the next full minute and press the Set button to set the time.
![datetime-set-time](https://user-images.githubusercontent.com/11667344/125080595-4b36e500-e0c5-11eb-9dd8-79a1d6a2acfe.jpg)

And this is how the date can be set:
![datetime-set-date](https://user-images.githubusercontent.com/11667344/125080635-568a1080-e0c5-11eb-84ce-f58c5fc7072b.jpg)

In both screens there is visual feedback when the Set button has done its work. The button gets disabled (gray text) until you change a value on the screen.
![datetime-set-disabled](https://user-images.githubusercontent.com/11667344/125080958-bc769800-e0c5-11eb-9fec-df79b890adb6.jpg)
