### PR TITLE
Suspend displayapp when it's not needed

### DIFF
--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -39,7 +39,6 @@ namespace Pinetime {
   namespace Applications {
     class DisplayApp {
     public:
-      enum class States { Idle, Running };
       enum class FullRefreshDirections { None, Up, Down, Left, Right, LeftAnim, RightAnim };
       enum class TouchModes { Gestures, Polling };
 
@@ -56,7 +55,7 @@ namespace Pinetime {
                  Pinetime::Controllers::MotorController& motorController,
                  Pinetime::Controllers::MotionController& motionController,
                  Pinetime::Controllers::TimerController& timerController);
-      void Start();
+      TaskHandle_t Start();
       void PushMessage(Display::Messages msg);
 
       void StartApp(Apps app, DisplayApp::FullRefreshDirections direction);
@@ -87,7 +86,6 @@ namespace Pinetime {
 
       TaskHandle_t taskHandle;
 
-      States state = States::Running;
       QueueHandle_t msgQueue;
 
       static constexpr uint8_t queueSize = 10;
@@ -103,8 +101,6 @@ namespace Pinetime {
       TouchModes touchMode = TouchModes::Gestures;
 
       TouchEvents OnTouchEvent();
-      void RunningState();
-      void IdleState();
       static void Process(void* instance);
       void InitHw();
       void Refresh();

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -130,7 +130,7 @@ void SystemTask::Work() {
   settingsController.Init();
 
   displayApp.Register(this);
-  displayApp.Start();
+  displayAppTaskHandle = displayApp.Start();
 
   displayApp.PushMessage(Pinetime::Applications::Display::Messages::UpdateBatteryLevel);
 
@@ -215,6 +215,7 @@ void SystemTask::Work() {
           spiNorFlash.Wakeup();
           lcd.Wakeup();
 
+          vTaskResume(displayAppTaskHandle);
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::GoToRunning);
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::UpdateBatteryLevel);
           heartRateApp.PushMessage(Pinetime::Applications::HeartRateTask::Messages::WakeUp);

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -132,6 +132,8 @@ namespace Pinetime {
       void UpdateMotion();
       bool stepCounterMustBeReset = false;
 
+      TaskHandle_t displayAppTaskHandle;
+
 #if configUSE_TRACE_FACILITY == 1
       SystemMonitor<FreeRtosMonitor> monitor;
 #else


### PR DESCRIPTION
Currently all FreeRTOS tasks have idle priority and they never suspend themselves other than for delay. AFAIK This wastes processing time as a task keeps running even if it does nothing until the kernel swaps out the task.

This PR makes displayapp loop once every 20ms, establishing a refresh rate of ~50Hz, and suspend as soon as it is done with all of it's work.

This has a visible effect on Paddle game, making it run smoother and faster.

EDIT: I think this behaviour is actually called blocking in FreeRTOS, but I also made displayapp actually suspend when the device goes to sleep.

EDIT2: The refresh rate probably ends up being 51.2Hz because 20ms gets rounded to 20 ticks and 1024Hz / 20 ticks = 51.2Hz