### PR TITLE
Adjust displayapp delay to compensate time spent

### DIFF
--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -114,6 +114,7 @@ namespace Pinetime {
 
       Apps nextApp = Apps::None;
       DisplayApp::FullRefreshDirections nextDirection;
+      TickType_t lastWakeTime;
     };
   }
 }


### PR DESCRIPTION
Makes displayapp run every 20ms more consistently by subtracting time spent executing from the next delay.

The simpler way to achieve the same results as #474. Whoops.