### PR TITLE
Fix cases where Get() from DirtyValue isn't used

### DIFF
--- a/src/displayapp/screens/Screen.h
+++ b/src/displayapp/screens/Screen.h
@@ -13,8 +13,12 @@ namespace Pinetime {
         DirtyValue() = default; // Use NSDMI
         explicit DirtyValue(T const& v) : value {v} {
         } // Use MIL and const-lvalue-ref
-        bool IsUpdated() const {
-          return isUpdated;
+        bool IsUpdated() {
+          if (this->isUpdated) {
+            this->isUpdated = false;
+            return true;
+          }
+          return false;
         }
         T const& Get() {
           this->isUpdated = false;


### PR DESCRIPTION
There are at least three cases where Get() isn't used. This causes IsUpdated() to always return true, because the isUpdated variable is only set to false when Get() is run.

Instead of running dummy Get()s, I made IsUpdated() set the value to false. Now IsUpdated() works as expected returning true when the value has been updated between calls.

https://github.com/JF002/InfiniTime/blob/4f378e8726fdcff72598aa6ed12eeaa6b3e61355/src/displayapp/screens/WatchFaceAnalog.cpp#L198
https://github.com/JF002/InfiniTime/blob/4f378e8726fdcff72598aa6ed12eeaa6b3e61355/src/displayapp/screens/WatchFaceDigital.cpp#L238
https://github.com/JF002/InfiniTime/blob/4f378e8726fdcff72598aa6ed12eeaa6b3e61355/src/displayapp/screens/PineTimeStyle.cpp#L330