### PR TITLE
Set correct refresh times for LVGL

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -43,6 +43,8 @@
 #include "displayapp/screens/settings/SettingDisplay.h"
 #include "displayapp/screens/settings/SettingSteps.h"
 
+#include "libs/lv_conf.h"
+
 using namespace Pinetime::Applications;
 using namespace Pinetime::Applications::Display;
 
@@ -123,10 +125,10 @@ void DisplayApp::Refresh() {
     case States::Running:
       RunningState();
       delta = xTaskGetTickCount() - lastWakeTime;
-      if (delta > 20) {
-        delta = 20;
+      if (delta > LV_DISP_DEF_REFR_PERIOD) {
+        delta = LV_DISP_DEF_REFR_PERIOD;
       }
-      queueTimeout = 20 - delta;
+      queueTimeout = LV_DISP_DEF_REFR_PERIOD - delta;
       break;
     default:
       queueTimeout = portMAX_DELAY;

--- a/src/libs/lv_conf.h
+++ b/src/libs/lv_conf.h
@@ -42,7 +42,7 @@
 
 /* Default display refresh period.
  * Can be changed in the display driver (`lv_disp_drv_t`).*/
-#define LV_DISP_DEF_REFR_PERIOD      30      /*[ms]*/
+#define LV_DISP_DEF_REFR_PERIOD      20      /*[ms]*/
 
 /* Dot Per Inch: used to initialize default sizes.
  * E.g. a button with width = LV_DPI / 2 -> half inch wide
@@ -112,7 +112,7 @@ typedef int16_t lv_coord_t;
  * Can be changed in the Input device driver (`lv_indev_drv_t`)*/
 
 /* Input device read period in milliseconds */
-#define LV_INDEV_DEF_READ_PERIOD          30
+#define LV_INDEV_DEF_READ_PERIOD          20
 
 /* Drag threshold in pixels */
 #define LV_INDEV_DEF_DRAG_LIMIT           10
@@ -127,7 +127,6 @@ typedef int16_t lv_coord_t;
 /* Repeated trigger period in long press [ms]
  * Time between `LV_EVENT_LONG_PRESSED_REPEAT */
 #define LV_INDEV_DEF_LONG_PRESS_REP_TIME  100
-
 
 /* Gesture threshold in pixels */
 #define LV_INDEV_DEF_GESTURE_LIMIT        50


### PR DESCRIPTION
After merging both #470 and #482, a new issue came up. LVGL would refuse to refresh in sync with displayapp, causing lag in some cases.

Here I fixed this issue by setting the refresh times in LVGL to 20ms.

The behaviour of the arc in Metronome has also changed with all these changes, ~~but it should be as intended now.~~

EDIT: There is still one more regression. In metronome, the dropdown menu can't be scrolled. Every value can still be reached by reopening the menu.