### PR TITLE
Fix slow scroll

### DIFF
--- a/src/displayapp/screens/Music.cpp
+++ b/src/displayapp/screens/Music.cpp
@@ -119,7 +119,6 @@ Music::Music(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Mus
   constexpr int8_t MIDDLE_OFFSET = -25;
   txtArtist = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtArtist, LV_LABEL_LONG_SROLL_CIRC);
-  lv_label_set_anim_speed(txtArtist, 1);
   lv_obj_align(txtArtist, nullptr, LV_ALIGN_IN_LEFT_MID, 12, MIDDLE_OFFSET + 1 * FONT_HEIGHT);
   lv_label_set_align(txtArtist, LV_ALIGN_IN_LEFT_MID);
   lv_obj_set_width(txtArtist, LV_HOR_RES - 12);
@@ -127,7 +126,6 @@ Music::Music(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Mus
 
   txtTrack = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtTrack, LV_LABEL_LONG_SROLL_CIRC);
-  lv_label_set_anim_speed(txtTrack, 1);
   lv_obj_align(txtTrack, nullptr, LV_ALIGN_IN_LEFT_MID, 12, MIDDLE_OFFSET + 2 * FONT_HEIGHT + LINE_PAD);
 
   lv_label_set_align(txtTrack, LV_ALIGN_IN_LEFT_MID);

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -184,7 +184,6 @@ Notifications::NotificationItem::NotificationItem(const char* title,
   }
   lv_label_set_text(alert_type, title);
   lv_label_set_long_mode(alert_type, LV_LABEL_LONG_SROLL_CIRC);
-  lv_label_set_anim_speed(alert_type, 3);
   lv_obj_set_width(alert_type, 180);
   lv_obj_align(alert_type, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 16);
 


### PR DESCRIPTION
After correcting LVGL time in #470, text scrolls much slower in Music and Notifications. they were set to scroll very slowly to compensate for LVGL running too fast. Removing the overrides makes the text scroll at a reasonable 25px/second, as defined in [lv_conf.h](https://github.com/JF002/InfiniTime/blob/d6cccc2dcd95a7d332ee657d1357ae060389f6e6/src/libs/lv_conf.h#L638).

Fixes #516