### PR TITLE
Code cleaning in Clocks (analog, digital & PineTimeStyle)

### DIFF
--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -55,9 +55,9 @@ void DateTime::UpdateTime(uint32_t systickCounter) {
   auto time = date::make_time(currentDateTime - dp);
   auto yearMonthDay = date::year_month_day(dp);
 
-  year = (int) yearMonthDay.year();
-  month = static_cast<Months>((unsigned) yearMonthDay.month());
-  day = (unsigned) yearMonthDay.day();
+  year = static_cast<int>(yearMonthDay.year());
+  month = static_cast<Months>(static_cast<unsigned>(yearMonthDay.month()));
+  day = static_cast<unsigned>(yearMonthDay.day());
   dayOfWeek = static_cast<Days>(date::weekday(yearMonthDay).iso_encoding());
 
   hour = time.hours().count();
@@ -75,31 +75,31 @@ void DateTime::UpdateTime(uint32_t systickCounter) {
 }
 
 const char* DateTime::MonthShortToString() {
-  return DateTime::MonthsString[(uint8_t) month];
+  return DateTime::MonthsString[static_cast<uint8_t>(month)];
 }
 
 const char* DateTime::MonthShortToStringLow() {
-  return DateTime::MonthsStringLow[(uint8_t) month];
+  return DateTime::MonthsStringLow[static_cast<uint8_t>(month)];
 }
 
 const char* DateTime::MonthsToStringLow() {
-  return DateTime::MonthsLow[(uint8_t) month];
+  return DateTime::MonthsLow[static_cast<uint8_t>(month)];
 }
 
 const char* DateTime::DayOfWeekToString() {
-  return DateTime::DaysString[(uint8_t) dayOfWeek];
+  return DateTime::DaysString[static_cast<uint8_t>(dayOfWeek)];
 }
 
 const char* DateTime::DayOfWeekShortToString() {
-  return DateTime::DaysStringShort[(uint8_t) dayOfWeek];
+  return DateTime::DaysStringShort[static_cast<uint8_t>(dayOfWeek)];
 }
 
 const char* DateTime::DayOfWeekToStringLow() {
-  return DateTime::DaysStringLow[(uint8_t) dayOfWeek];
+  return DateTime::DaysStringLow[static_cast<uint8_t>(dayOfWeek)];
 }
 
 const char* DateTime::DayOfWeekShortToStringLow() {
-  return DateTime::DaysStringShortLow[(uint8_t) dayOfWeek];
+  return DateTime::DaysStringShortLow[static_cast<uint8_t>(dayOfWeek)];
 }
 
 void DateTime::Register(Pinetime::System::SystemTask* systemTask) {

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -2,11 +2,6 @@
 
 #include <date/date.h>
 #include <lvgl/lvgl.h>
-#include <cstdio>
-#include "BatteryIcon.h"
-#include "BleIcon.h"
-#include "NotificationIcon.h"
-#include "Symbols.h"
 #include "components/battery/BatteryController.h"
 #include "components/motion/MotionController.h"
 #include "components/ble/BleController.h"
@@ -89,16 +84,3 @@ std::unique_ptr<Screen> Clock::PineTimeStyleScreen() {
                                                      settingsController,
                                                      motionController);
 }
-
-/*
-// Examples for more watch faces
-std::unique_ptr<Screen> Clock::WatchFaceMinimalScreen() {
-  return std::make_unique<Screens::WatchFaceMinimal>(app, dateTimeController, batteryController, bleController, notificatioManager,
-settingsController);
-}
-
-std::unique_ptr<Screen> Clock::WatchFaceCustomScreen() {
-  return std::make_unique<Screens::WatchFaceCustom>(app, dateTimeController, batteryController, bleController, notificatioManager,
-settingsController);
-}
-*/

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -9,9 +9,6 @@
 #include "components/datetime/DateTimeController.h"
 
 namespace Pinetime {
-  namespace Drivers {
-    class BMA421;
-  }
   namespace Controllers {
     class Settings;
     class Battery;
@@ -51,10 +48,6 @@ namespace Pinetime {
         std::unique_ptr<Screen> WatchFaceDigitalScreen();
         std::unique_ptr<Screen> WatchFaceAnalogScreen();
         std::unique_ptr<Screen> PineTimeStyleScreen();
-
-        // Examples for more watch faces
-        // std::unique_ptr<Screen> WatchFaceMinimalScreen();
-        // std::unique_ptr<Screen> WatchFaceCustomScreen();
       };
     }
   }

--- a/src/displayapp/screens/PineTimeStyle.cpp
+++ b/src/displayapp/screens/PineTimeStyle.cpp
@@ -51,7 +51,6 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
     notificatioManager {notificatioManager},
     settingsController {settingsController},
     motionController {motionController} {
-
   /* This sets the watchface number to return to after leaving the menu */
   settingsController.SetClockFace(2);
 
@@ -62,7 +61,6 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   displayedChar[4] = 0;
 
   /* Create a 200px wide background rectangle */
-
   timebar = lv_obj_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_bg_color(timebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
   lv_obj_set_style_local_radius(timebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
@@ -70,7 +68,6 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   lv_obj_align(timebar, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 5, 0);
 
   /* Display the time */
-
   timeDD1 = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(timeDD1, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &open_sans_light);
   lv_obj_set_style_local_text_color(timeDD1, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x008080));
@@ -90,7 +87,6 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   lv_obj_align(timeAMPM, timebar, LV_ALIGN_IN_BOTTOM_LEFT, 2, -20);
 
   /* Create a 40px wide bar down the right side of the screen */
-
   sidebar = lv_obj_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_bg_color(sidebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x008080));
   lv_obj_set_style_local_radius(sidebar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
@@ -98,7 +94,6 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   lv_obj_align(sidebar, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, 0, 0);
 
   /* Display icons */
-
   batteryIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(batteryIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
   lv_label_set_text(batteryIcon, Symbols::batteryFull);
@@ -117,7 +112,6 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   lv_obj_align(notificationIcon, sidebar, LV_ALIGN_IN_TOP_MID, 0, 40);
 
   /* Calendar icon */
-
   calendarOuter = lv_obj_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_bg_color(calendarOuter, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
   lv_obj_set_style_local_radius(calendarOuter, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
@@ -155,7 +149,6 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   lv_obj_align(calendarCrossBar2, calendarBar2, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
 
   /* Display date */
-
   dateDayOfWeek = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(dateDayOfWeek, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
   lv_label_set_text(dateDayOfWeek, "THU");
@@ -223,26 +216,17 @@ bool PineTimeStyle::Refresh() {
 
   bleState = bleController.IsConnected();
   if (bleState.IsUpdated()) {
-    if (bleState.Get() == true) {
-      lv_label_set_text(bleIcon, BleIcon::GetIcon(true));
-      lv_obj_realign(bleIcon);
-    } else {
-      lv_label_set_text(bleIcon, BleIcon::GetIcon(false));
-    }
+    lv_label_set_text(bleIcon, BleIcon::GetIcon(bleState.Get()));
+    lv_obj_realign(bleIcon);
   }
 
   notificationState = notificatioManager.AreNewNotificationsAvailable();
   if (notificationState.IsUpdated()) {
-    if (notificationState.Get() == true) {
-      lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(true));
-      lv_obj_realign(notificationIcon);
-    } else {
-      lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(false));
-    }
+    lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
+    lv_obj_realign(notificationIcon);
   }
 
   currentDateTime = dateTimeController.CurrentDateTime();
-
   if (currentDateTime.IsUpdated()) {
     auto newDateTime = currentDateTime.Get();
 
@@ -250,9 +234,9 @@ bool PineTimeStyle::Refresh() {
     auto time = date::make_time(newDateTime - dp);
     auto yearMonthDay = date::year_month_day(dp);
 
-    auto year = (int) yearMonthDay.year();
-    auto month = static_cast<Pinetime::Controllers::DateTime::Months>((unsigned) yearMonthDay.month());
-    auto day = (unsigned) yearMonthDay.day();
+    auto year = static_cast<int>(yearMonthDay.year());
+    auto month = static_cast<Pinetime::Controllers::DateTime::Months>(static_cast<unsigned>(yearMonthDay.month()));
+    auto day = static_cast<unsigned>(yearMonthDay.day());
     auto dayOfWeek = static_cast<Pinetime::Controllers::DateTime::Days>(date::weekday(yearMonthDay).iso_encoding());
 
     int hour = time.hours().count();
@@ -263,9 +247,8 @@ bool PineTimeStyle::Refresh() {
 
     char hoursChar[3];
     char ampmChar[5];
-
     if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-      sprintf(hoursChar, "%02d", hour);
+        sprintf(hoursChar, "%02d", hour);
     } else {
       if (hour == 0 && hour != 12) {
         hour = 12;
@@ -282,41 +265,26 @@ bool PineTimeStyle::Refresh() {
       sprintf(hoursChar, "%02d", hour);
     }
 
-    if (hoursChar[0] != displayedChar[0] || hoursChar[1] != displayedChar[1] || minutesChar[0] != displayedChar[2] ||
+    if (hoursChar[0] != displayedChar[0] or hoursChar[1] != displayedChar[1] or minutesChar[0] != displayedChar[2] or
         minutesChar[1] != displayedChar[3]) {
       displayedChar[0] = hoursChar[0];
       displayedChar[1] = hoursChar[1];
       displayedChar[2] = minutesChar[0];
       displayedChar[3] = minutesChar[1];
 
-      char hourStr[3];
-      char minStr[3];
-
       if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
         lv_label_set_text(timeAMPM, ampmChar);
       }
 
-      /* Display the time as 2 pairs of digits */
-      sprintf(hourStr, "%c%c", hoursChar[0], hoursChar[1]);
-      lv_label_set_text(timeDD1, hourStr);
-
-      sprintf(minStr, "%c%c", minutesChar[0], minutesChar[1]);
-      lv_label_set_text(timeDD2, minStr);
+      lv_label_set_text_fmt(timeDD1, "%s", hoursChar);
+      lv_label_set_text_fmt(timeDD2, "%s", minutesChar);
     }
 
     if ((year != currentYear) || (month != currentMonth) || (dayOfWeek != currentDayOfWeek) || (day != currentDay)) {
-      char dayOfWeekStr[4];
-      char dayStr[3];
-      char monthStr[4];
-
-      sprintf(dayOfWeekStr, "%s", dateTimeController.DayOfWeekShortToString());
-      sprintf(dayStr, "%d", day);
-      sprintf(monthStr, "%s", dateTimeController.MonthShortToString());
-
-      lv_label_set_text(dateDayOfWeek, dayOfWeekStr);
-      lv_label_set_text(dateDay, dayStr);
+      lv_label_set_text_fmt(dateDayOfWeek, "%s", dateTimeController.DayOfWeekShortToString());
+      lv_label_set_text_fmt(dateDay, "%d", day);
       lv_obj_realign(dateDay);
-      lv_label_set_text(dateMonth, monthStr);
+      lv_label_set_text_fmt(dateMonth, "%s", dateTimeController.MonthShortToString());
 
       currentYear = year;
       currentMonth = month;

--- a/src/displayapp/screens/PineTimeStyle.h
+++ b/src/displayapp/screens/PineTimeStyle.h
@@ -32,8 +32,6 @@ namespace Pinetime {
 
         bool Refresh() override;
 
-        void OnObjectEvent(lv_obj_t* pObj, lv_event_t i);
-
       private:
         char displayedChar[5];
 
@@ -67,9 +65,6 @@ namespace Pinetime {
         lv_obj_t* calendarBar2;
         lv_obj_t* calendarCrossBar1;
         lv_obj_t* calendarCrossBar2;
-        lv_obj_t* heartbeatIcon;
-        lv_obj_t* heartbeatValue;
-        lv_obj_t* heartbeatBpm;
         lv_obj_t* notificationIcon;
         lv_obj_t* stepGauge;
         lv_color_t needle_colors[1];

--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -10,38 +10,37 @@ LV_IMG_DECLARE(bg_clock);
 using namespace Pinetime::Applications::Screens;
 
 namespace {
-
-constexpr auto HOUR_LENGTH = 70;
-constexpr auto MINUTE_LENGTH = 90;
-constexpr auto SECOND_LENGTH = 110;
+constexpr int16_t HourLength = 70;
+constexpr int16_t MinuteLength = 90;
+constexpr int16_t SecondLength = 110;
 
 // sin(90) = 1 so the value of _lv_trigo_sin(90) is the scaling factor
 const auto LV_TRIG_SCALE = _lv_trigo_sin(90);
 
-int16_t cosine(int16_t angle) {
+int16_t Cosine(int16_t angle) {
   return _lv_trigo_sin(angle + 90);
 }
 
-int16_t sine(int16_t angle) {
+int16_t Sine(int16_t angle) {
   return _lv_trigo_sin(angle);
 }
 
-int16_t coordinate_x_relocate(int16_t x) {
+int16_t CoordinateXRelocate(int16_t x) {
   return (x + LV_HOR_RES / 2);
 }
 
-int16_t coordinate_y_relocate(int16_t y) {
+int16_t CoordinateYRelocate(int16_t y) {
   return std::abs(y - LV_HOR_RES / 2);
 }
 
-lv_point_t coordinate_relocate(int16_t radius, int16_t angle) {
+lv_point_t CoordinateRelocate(int16_t radius, int16_t angle) {
   return lv_point_t{
-    .x = coordinate_x_relocate(radius * static_cast<int32_t>(sine(angle)) / LV_TRIG_SCALE),
-    .y = coordinate_y_relocate(radius * static_cast<int32_t>(cosine(angle)) / LV_TRIG_SCALE)
+    .x = CoordinateXRelocate(radius * static_cast<int32_t>(Sine(angle)) / LV_TRIG_SCALE),
+    .y = CoordinateYRelocate(radius * static_cast<int32_t>(Cosine(angle)) / LV_TRIG_SCALE)
   };
 }
 
-} // namespace
+}
 
 WatchFaceAnalog::WatchFaceAnalog(Pinetime::Applications::DisplayApp* app,
                                  Controllers::DateTime& dateTimeController,
@@ -123,7 +122,6 @@ WatchFaceAnalog::WatchFaceAnalog(Pinetime::Applications::DisplayApp* app,
 }
 
 WatchFaceAnalog::~WatchFaceAnalog() {
-
   lv_style_reset(&hour_line_style);
   lv_style_reset(&hour_line_style_trace);
   lv_style_reset(&minute_line_style);
@@ -134,18 +132,17 @@ WatchFaceAnalog::~WatchFaceAnalog() {
 }
 
 void WatchFaceAnalog::UpdateClock() {
-
   hour = dateTimeController.Hours();
   minute = dateTimeController.Minutes();
   second = dateTimeController.Seconds();
 
   if (sMinute != minute) {
     auto const angle = minute * 6;
-    minute_point[0] = coordinate_relocate(30, angle);
-    minute_point[1] = coordinate_relocate(MINUTE_LENGTH, angle);
+    minute_point[0] = CoordinateRelocate(30, angle);
+    minute_point[1] = CoordinateRelocate(MinuteLength, angle);
 
-    minute_point_trace[0] = coordinate_relocate(5, angle);
-    minute_point_trace[1] = coordinate_relocate(31, angle);
+    minute_point_trace[0] = CoordinateRelocate(5, angle);
+    minute_point_trace[1] = CoordinateRelocate(31, angle);
 
     lv_line_set_points(minute_body, minute_point, 2);
     lv_line_set_points(minute_body_trace, minute_point_trace, 2);
@@ -156,11 +153,11 @@ void WatchFaceAnalog::UpdateClock() {
     sMinute = minute;
     auto const angle = (hour * 30 + minute / 2);
 
-    hour_point[0] = coordinate_relocate(30, angle);
-    hour_point[1] = coordinate_relocate(HOUR_LENGTH, angle);
+    hour_point[0] = CoordinateRelocate(30, angle);
+    hour_point[1] = CoordinateRelocate(HourLength, angle);
 
-    hour_point_trace[0] = coordinate_relocate(5, angle);
-    hour_point_trace[1] = coordinate_relocate(31, angle);
+    hour_point_trace[0] = CoordinateRelocate(5, angle);
+    hour_point_trace[1] = CoordinateRelocate(31, angle);
 
     lv_line_set_points(hour_body, hour_point, 2);
     lv_line_set_points(hour_body_trace, hour_point_trace, 2);
@@ -170,8 +167,8 @@ void WatchFaceAnalog::UpdateClock() {
     sSecond = second;
     auto const angle = second * 6;
 
-    second_point[0] = coordinate_relocate(-20, angle);
-    second_point[1] = coordinate_relocate(SECOND_LENGTH, angle);
+    second_point[0] = CoordinateRelocate(-20, angle);
+    second_point[1] = CoordinateRelocate(SecondLength, angle);
     lv_line_set_points(second_body, second_point, 2);
   }
 }
@@ -186,16 +183,12 @@ bool WatchFaceAnalog::Refresh() {
   notificationState = notificationManager.AreNewNotificationsAvailable();
 
   if (notificationState.IsUpdated()) {
-    if (notificationState.Get() == true)
-      lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(true));
-    else
-      lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(false));
+    lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
   }
 
   currentDateTime = dateTimeController.CurrentDateTime();
 
   if (currentDateTime.IsUpdated()) {
-
     month = dateTimeController.Month();
     day = dateTimeController.Day();
     dayOfWeek = dateTimeController.DayOfWeek();
@@ -203,7 +196,6 @@ bool WatchFaceAnalog::Refresh() {
     UpdateClock();
 
     if ((month != currentMonth) || (dayOfWeek != currentDayOfWeek) || (day != currentDay)) {
-
       lv_label_set_text_fmt(label_date_day, "%s\n%02i", dateTimeController.DayOfWeekShortToString(), day);
 
       currentMonth = month;

--- a/src/displayapp/screens/WatchFaceAnalog.h
+++ b/src/displayapp/screens/WatchFaceAnalog.h
@@ -58,14 +58,12 @@ namespace Pinetime {
         lv_obj_t* minute_body_trace;
         lv_obj_t* second_body;
 
-        // ##
         lv_point_t hour_point[2];
         lv_point_t hour_point_trace[2];
         lv_point_t minute_point[2];
         lv_point_t minute_point_trace[2];
         lv_point_t second_point[2];
 
-        // ##
         lv_style_t hour_line_style;
         lv_style_t hour_line_style_trace;
         lv_style_t minute_line_style;

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -12,9 +12,6 @@
 #include "components/ble/NotificationManager.h"
 #include "components/heartrate/HeartRateController.h"
 #include "components/motion/MotionController.h"
-#include "components/settings/Settings.h"
-#include "../DisplayApp.h"
-
 using namespace Pinetime::Applications::Screens;
 
 WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
@@ -36,12 +33,6 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
     motionController {motionController} {
   settingsController.SetClockFace(0);
 
-  displayedChar[0] = 0;
-  displayedChar[1] = 0;
-  displayedChar[2] = 0;
-  displayedChar[3] = 0;
-  displayedChar[4] = 0;
-
   batteryIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text(batteryIcon, Symbols::batteryFull);
   lv_obj_align(batteryIcon, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, -5, 2);
@@ -56,7 +47,7 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   lv_label_set_text(bleIcon, Symbols::bluetooth);
   lv_obj_align(bleIcon, batteryPlug, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 
-  notificationIcon = lv_label_create(lv_scr_act(), NULL);
+  notificationIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FF00));
   lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(false));
   lv_obj_align(notificationIcon, nullptr, LV_ALIGN_IN_TOP_LEFT, 10, 0);
@@ -111,17 +102,13 @@ bool WatchFaceDigital::Refresh() {
   if (batteryPercentRemaining.IsUpdated()) {
     auto batteryPercent = batteryPercentRemaining.Get();
     lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
-    auto isCharging = batteryController.IsCharging() || batteryController.IsPowerPresent();
+    auto isCharging = batteryController.IsCharging() or batteryController.IsPowerPresent();
     lv_label_set_text(batteryPlug, BatteryIcon::GetPlugIcon(isCharging));
   }
 
   bleState = bleController.IsConnected();
   if (bleState.IsUpdated()) {
-    if (bleState.Get() == true) {
-      lv_label_set_text(bleIcon, BleIcon::GetIcon(true));
-    } else {
-      lv_label_set_text(bleIcon, BleIcon::GetIcon(false));
-    }
+    lv_label_set_text(bleIcon, BleIcon::GetIcon(bleState.Get()));
   }
   lv_obj_align(batteryIcon, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, -5, 5);
   lv_obj_align(batteryPlug, batteryIcon, LV_ALIGN_OUT_LEFT_MID, -5, 0);
@@ -129,10 +116,7 @@ bool WatchFaceDigital::Refresh() {
 
   notificationState = notificatioManager.AreNewNotificationsAvailable();
   if (notificationState.IsUpdated()) {
-    if (notificationState.Get() == true)
-      lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(true));
-    else
-      lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(false));
+    lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
   }
 
   currentDateTime = dateTimeController.CurrentDateTime();
@@ -144,9 +128,9 @@ bool WatchFaceDigital::Refresh() {
     auto time = date::make_time(newDateTime - dp);
     auto yearMonthDay = date::year_month_day(dp);
 
-    auto year = (int) yearMonthDay.year();
-    auto month = static_cast<Pinetime::Controllers::DateTime::Months>((unsigned) yearMonthDay.month());
-    auto day = (unsigned) yearMonthDay.day();
+    auto year = static_cast<int>(yearMonthDay.year());
+    auto month = static_cast<Pinetime::Controllers::DateTime::Months>(static_cast<unsigned>(yearMonthDay.month()));
+    auto day = static_cast<unsigned>(yearMonthDay.day());
     auto dayOfWeek = static_cast<Pinetime::Controllers::DateTime::Days>(date::weekday(yearMonthDay).iso_encoding());
 
     int hour = time.hours().count();
@@ -175,14 +159,12 @@ bool WatchFaceDigital::Refresh() {
       sprintf(hoursChar, "%02d", hour);
     }
 
-    if (hoursChar[0] != displayedChar[0] || hoursChar[1] != displayedChar[1] || minutesChar[0] != displayedChar[2] ||
-        minutesChar[1] != displayedChar[3]) {
+    if ((hoursChar[0] != displayedChar[0]) or (hoursChar[1] != displayedChar[1]) or (minutesChar[0] != displayedChar[2]) or
+        (minutesChar[1] != displayedChar[3])) {
       displayedChar[0] = hoursChar[0];
       displayedChar[1] = hoursChar[1];
       displayedChar[2] = minutesChar[0];
       displayedChar[3] = minutesChar[1];
-
-      char timeStr[6];
 
       if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
         lv_label_set_text(label_time_ampm, ampmChar);
@@ -191,8 +173,7 @@ bool WatchFaceDigital::Refresh() {
         }
       }
 
-      sprintf(timeStr, "%c%c:%c%c", hoursChar[0], hoursChar[1], minutesChar[0], minutesChar[1]);
-      lv_label_set_text(label_time, timeStr);
+      lv_label_set_text_fmt(label_time, "%s:%s", hoursChar, minutesChar);
 
       if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
         lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
@@ -202,13 +183,11 @@ bool WatchFaceDigital::Refresh() {
     }
 
     if ((year != currentYear) || (month != currentMonth) || (dayOfWeek != currentDayOfWeek) || (day != currentDay)) {
-      char dateStr[22];
       if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-        sprintf(dateStr, "%s %d %s %d", dateTimeController.DayOfWeekShortToString(), day, dateTimeController.MonthShortToString(), year);
+        lv_label_set_text_fmt(label_date, "%s %d %s %d", dateTimeController.DayOfWeekShortToString(), day, dateTimeController.MonthShortToString(), year);
       } else {
-        sprintf(dateStr, "%s %s %d %d", dateTimeController.DayOfWeekShortToString(), dateTimeController.MonthShortToString(), day, year);
+        lv_label_set_text_fmt(label_date, "%s %s %d %d", dateTimeController.DayOfWeekShortToString(), dateTimeController.MonthShortToString(), day, year);
       }
-      lv_label_set_text(label_date, dateStr);
       lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_CENTER, 0, 60);
 
       currentYear = year;

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -35,10 +35,8 @@ namespace Pinetime {
 
         bool Refresh() override;
 
-        void OnObjectEvent(lv_obj_t* pObj, lv_event_t i);
-
       private:
-        char displayedChar[5];
+        char displayedChar[5] {};
 
         uint16_t currentYear = 1970;
         Pinetime::Controllers::DateTime::Months currentMonth = Pinetime::Controllers::DateTime::Months::Unknown;
@@ -63,7 +61,6 @@ namespace Pinetime {
         lv_obj_t* batteryPlug;
         lv_obj_t* heartbeatIcon;
         lv_obj_t* heartbeatValue;
-        lv_obj_t* heartbeatBpm;
         lv_obj_t* stepIcon;
         lv_obj_t* stepValue;
         lv_obj_t* notificationIcon;


### PR DESCRIPTION
PR #232 by @nscooling is too old to be easily mergeable. I took most of the changes from this PR and applied them to analog and PineTimeStyle watchface too : 


- Replaced unnecessary sprintf statements with the build-in lvgl lv_label_set_text_fmt function (designed for that exact purpose)
- Cleaned up Clock construction and member-initialisation list, where the NSDMI can be used in preference (e.g. defaults zero values and nullptr)
 - Cleaned up some logic code
 - Change some instances of || to or (this is a C++ keyword, as is and and not and has been since the original C++98 standard)
 - Ran Clock.* through clang-tidy based on .clang-format file at project root
 - Replaced any remaining NULL with nullptr
 - Replaced C-style casts with C++ casts

My apologies to @nscooling for not merging the original PR sooner.