### PR TITLE
Remove unnecessary C-style casts with BLE UUIDs

### DIFF
--- a/src/components/ble/AlertNotificationClient.cpp
+++ b/src/components/ble/AlertNotificationClient.cpp
@@ -55,7 +55,7 @@ bool AlertNotificationClient::OnDiscoveryEvent(uint16_t connectionHandle, const 
     return true;
   }
 
-  if (service != nullptr && ble_uuid_cmp(((ble_uuid_t*) &ansServiceUuid), &service->uuid.u) == 0) {
+  if (service != nullptr && ble_uuid_cmp(&ansServiceUuid.u, &service->uuid.u) == 0) {
     NRF_LOG_INFO("ANS discovered : 0x%x - 0x%x", service->start_handle, service->end_handle);
     ansStartHandle = service->start_handle;
     ansEndHandle = service->end_handle;
@@ -80,21 +80,21 @@ int AlertNotificationClient::OnCharacteristicsDiscoveryEvent(uint16_t connection
     } else
       onServiceDiscovered(connectionHandle);
   } else {
-    if (characteristic != nullptr && ble_uuid_cmp(((ble_uuid_t*) &supportedNewAlertCategoryUuid), &characteristic->uuid.u) == 0) {
+    if (characteristic != nullptr && ble_uuid_cmp(&supportedNewAlertCategoryUuid.u, &characteristic->uuid.u) == 0) {
       NRF_LOG_INFO("ANS Characteristic discovered : supportedNewAlertCategoryUuid");
       supportedNewAlertCategoryHandle = characteristic->val_handle;
-    } else if (characteristic != nullptr && ble_uuid_cmp(((ble_uuid_t*) &supportedUnreadAlertCategoryUuid), &characteristic->uuid.u) == 0) {
+    } else if (characteristic != nullptr && ble_uuid_cmp(&supportedUnreadAlertCategoryUuid.u, &characteristic->uuid.u) == 0) {
       NRF_LOG_INFO("ANS Characteristic discovered : supportedUnreadAlertCategoryUuid");
       supportedUnreadAlertCategoryHandle = characteristic->val_handle;
-    } else if (characteristic != nullptr && ble_uuid_cmp(((ble_uuid_t*) &newAlertUuid), &characteristic->uuid.u) == 0) {
+    } else if (characteristic != nullptr && ble_uuid_cmp(&newAlertUuid.u, &characteristic->uuid.u) == 0) {
       NRF_LOG_INFO("ANS Characteristic discovered : newAlertUuid");
       newAlertHandle = characteristic->val_handle;
       newAlertDefHandle = characteristic->def_handle;
       isCharacteristicDiscovered = true;
-    } else if (characteristic != nullptr && ble_uuid_cmp(((ble_uuid_t*) &unreadAlertStatusUuid), &characteristic->uuid.u) == 0) {
+    } else if (characteristic != nullptr && ble_uuid_cmp(&unreadAlertStatusUuid.u, &characteristic->uuid.u) == 0) {
       NRF_LOG_INFO("ANS Characteristic discovered : unreadAlertStatusUuid");
       unreadAlertStatusHandle = characteristic->val_handle;
-    } else if (characteristic != nullptr && ble_uuid_cmp(((ble_uuid_t*) &controlPointUuid), &characteristic->uuid.u) == 0) {
+    } else if (characteristic != nullptr && ble_uuid_cmp(&controlPointUuid.u, &characteristic->uuid.u) == 0) {
       NRF_LOG_INFO("ANS Characteristic discovered : controlPointUuid");
       controlPointHandle = characteristic->val_handle;
     } else
@@ -119,7 +119,7 @@ int AlertNotificationClient::OnDescriptorDiscoveryEventCallback(uint16_t connect
                                                                 uint16_t characteristicValueHandle,
                                                                 const ble_gatt_dsc* descriptor) {
   if (error->status == 0) {
-    if (characteristicValueHandle == newAlertHandle && ble_uuid_cmp(((ble_uuid_t*) &newAlertUuid), &descriptor->uuid.u)) {
+    if (characteristicValueHandle == newAlertHandle && ble_uuid_cmp(&newAlertUuid.u, &descriptor->uuid.u)) {
       if (newAlertDescriptorHandle == 0) {
         NRF_LOG_INFO("ANS Descriptor discovered : %d", descriptor->handle);
         newAlertDescriptorHandle = descriptor->handle;

--- a/src/components/ble/AlertNotificationService.cpp
+++ b/src/components/ble/AlertNotificationService.cpp
@@ -26,11 +26,8 @@ void AlertNotificationService::Init() {
 }
 
 AlertNotificationService::AlertNotificationService(System::SystemTask& systemTask, NotificationManager& notificationManager)
-  : characteristicDefinition {{.uuid = (ble_uuid_t*) &ansCharUuid,
-                               .access_cb = AlertNotificationCallback,
-                               .arg = this,
-                               .flags = BLE_GATT_CHR_F_WRITE},
-                              {.uuid = (ble_uuid_t*) &notificationEventUuid,
+  : characteristicDefinition {{.uuid = &ansCharUuid.u, .access_cb = AlertNotificationCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE},
+                              {.uuid = &notificationEventUuid.u,
                                .access_cb = AlertNotificationCallback,
                                .arg = this,
                                .flags = BLE_GATT_CHR_F_NOTIFY,
@@ -39,7 +36,7 @@ AlertNotificationService::AlertNotificationService(System::SystemTask& systemTas
     serviceDefinition {
       {/* Device Information Service */
        .type = BLE_GATT_SVC_TYPE_PRIMARY,
-       .uuid = (ble_uuid_t*) &ansUuid,
+       .uuid = &ansUuid.u,
        .characteristics = characteristicDefinition},
       {0},
     },

--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -14,7 +14,7 @@ int BatteryInformationServiceCallback(uint16_t conn_handle, uint16_t attr_handle
 
 BatteryInformationService::BatteryInformationService(Controllers::Battery& batteryController)
   : batteryController {batteryController},
-    characteristicDefinition {{.uuid = (ble_uuid_t*) &batteryLevelUuid,
+    characteristicDefinition {{.uuid = &batteryLevelUuid.u,
                                .access_cb = BatteryInformationServiceCallback,
                                .arg = this,
                                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
@@ -23,7 +23,7 @@ BatteryInformationService::BatteryInformationService(Controllers::Battery& batte
     serviceDefinition {
       {/* Device Information Service */
        .type = BLE_GATT_SVC_TYPE_PRIMARY,
-       .uuid = (ble_uuid_t*) &batteryInformationServiceUuid,
+       .uuid = &batteryInformationServiceUuid.u,
        .characteristics = characteristicDefinition},
       {0},
     } {

--- a/src/components/ble/CurrentTimeClient.cpp
+++ b/src/components/ble/CurrentTimeClient.cpp
@@ -47,7 +47,7 @@ bool CurrentTimeClient::OnDiscoveryEvent(uint16_t connectionHandle, const ble_ga
     return true;
   }
 
-  if (service != nullptr && ble_uuid_cmp(((ble_uuid_t*) &ctsServiceUuid), &service->uuid.u) == 0) {
+  if (service != nullptr && ble_uuid_cmp(&ctsServiceUuid.u, &service->uuid.u) == 0) {
     NRF_LOG_INFO("CTS discovered : 0x%x - 0x%x", service->start_handle, service->end_handle);
     isDiscovered = true;
     ctsStartHandle = service->start_handle;
@@ -72,7 +72,7 @@ int CurrentTimeClient::OnCharacteristicDiscoveryEvent(uint16_t conn_handle,
     return 0;
   }
 
-  if (characteristic != nullptr && ble_uuid_cmp(((ble_uuid_t*) &currentTimeCharacteristicUuid), &characteristic->uuid.u) == 0) {
+  if (characteristic != nullptr && ble_uuid_cmp(&currentTimeCharacteristicUuid.u, &characteristic->uuid.u) == 0) {
     NRF_LOG_INFO("CTS Characteristic discovered : 0x%x", characteristic->val_handle);
     isCharacteristicDiscovered = true;
     currentTimeHandle = characteristic->val_handle;

--- a/src/components/ble/CurrentTimeService.cpp
+++ b/src/components/ble/CurrentTimeService.cpp
@@ -53,7 +53,7 @@ int CurrentTimeService::OnTimeAccessed(uint16_t conn_handle, uint16_t attr_handl
 }
 
 CurrentTimeService::CurrentTimeService(DateTime& dateTimeController)
-  : characteristicDefinition {{.uuid = (ble_uuid_t*) &ctChrUuid,
+  : characteristicDefinition {{.uuid = &ctChrUuid.u,
                                .access_cb = CTSCallback,
 
                                .arg = this,
@@ -62,7 +62,7 @@ CurrentTimeService::CurrentTimeService(DateTime& dateTimeController)
     serviceDefinition {
       {/* Device Information Service */
        .type = BLE_GATT_SVC_TYPE_PRIMARY,
-       .uuid = (ble_uuid_t*) &ctsUuid,
+       .uuid = &ctsUuid.u,
        .characteristics = characteristicDefinition},
       {0},
     },

--- a/src/components/ble/DeviceInformationService.cpp
+++ b/src/components/ble/DeviceInformationService.cpp
@@ -56,37 +56,37 @@ int DeviceInformationService::OnDeviceInfoRequested(uint16_t conn_handle, uint16
 
 DeviceInformationService::DeviceInformationService()
   : characteristicDefinition {{
-                                .uuid = (ble_uuid_t*) &manufacturerNameUuid,
+                                .uuid = &manufacturerNameUuid.u,
                                 .access_cb = DeviceInformationCallback,
                                 .arg = this,
                                 .flags = BLE_GATT_CHR_F_READ,
                               },
                               {
-                                .uuid = (ble_uuid_t*) &modelNumberUuid,
+                                .uuid = &modelNumberUuid.u,
                                 .access_cb = DeviceInformationCallback,
                                 .arg = this,
                                 .flags = BLE_GATT_CHR_F_READ,
                               },
                               {
-                                .uuid = (ble_uuid_t*) &serialNumberUuid,
+                                .uuid = &serialNumberUuid.u,
                                 .access_cb = DeviceInformationCallback,
                                 .arg = this,
                                 .flags = BLE_GATT_CHR_F_READ,
                               },
                               {
-                                .uuid = (ble_uuid_t*) &fwRevisionUuid,
+                                .uuid = &fwRevisionUuid.u,
                                 .access_cb = DeviceInformationCallback,
                                 .arg = this,
                                 .flags = BLE_GATT_CHR_F_READ,
                               },
                               {
-                                .uuid = (ble_uuid_t*) &hwRevisionUuid,
+                                .uuid = &hwRevisionUuid.u,
                                 .access_cb = DeviceInformationCallback,
                                 .arg = this,
                                 .flags = BLE_GATT_CHR_F_READ,
                               },
                               {
-                                .uuid = (ble_uuid_t*) &swRevisionUuid,
+                                .uuid = &swRevisionUuid.u,
                                 .access_cb = DeviceInformationCallback,
                                 .arg = this,
                                 .flags = BLE_GATT_CHR_F_READ,
@@ -95,7 +95,7 @@ DeviceInformationService::DeviceInformationService()
     serviceDefinition {
       {/* Device Information Service */
        .type = BLE_GATT_SVC_TYPE_PRIMARY,
-       .uuid = (ble_uuid_t*) &deviceInfoUuid,
+       .uuid = &deviceInfoUuid.u,
        .characteristics = characteristicDefinition},
       {0},
     } {

--- a/src/components/ble/HeartRateService.cpp
+++ b/src/components/ble/HeartRateService.cpp
@@ -18,7 +18,7 @@ namespace {
 HeartRateService::HeartRateService(Pinetime::System::SystemTask& system, Controllers::HeartRateController& heartRateController)
   : system {system},
     heartRateController {heartRateController},
-    characteristicDefinition {{.uuid = (ble_uuid_t*) &heartRateMeasurementUuid,
+    characteristicDefinition {{.uuid = &heartRateMeasurementUuid.u,
                                .access_cb = HeartRateServiceServiceCallback,
                                .arg = this,
                                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
@@ -27,7 +27,7 @@ HeartRateService::HeartRateService(Pinetime::System::SystemTask& system, Control
     serviceDefinition {
       {/* Device Information Service */
        .type = BLE_GATT_SVC_TYPE_PRIMARY,
-       .uuid = (ble_uuid_t*) &heartRateServiceUuid,
+       .uuid = &heartRateServiceUuid.u,
        .characteristics = characteristicDefinition},
       {0},
     } {

--- a/src/components/ble/ImmediateAlertService.cpp
+++ b/src/components/ble/ImmediateAlertService.cpp
@@ -32,7 +32,7 @@ ImmediateAlertService::ImmediateAlertService(Pinetime::System::SystemTask& syste
                                              Pinetime::Controllers::NotificationManager& notificationManager)
   : systemTask {systemTask},
     notificationManager {notificationManager},
-    characteristicDefinition {{.uuid = (ble_uuid_t*) &alertLevelUuid,
+    characteristicDefinition {{.uuid = &alertLevelUuid.u,
                                .access_cb = AlertLevelCallback,
                                .arg = this,
                                .flags = BLE_GATT_CHR_F_WRITE_NO_RSP,
@@ -41,7 +41,7 @@ ImmediateAlertService::ImmediateAlertService(Pinetime::System::SystemTask& syste
     serviceDefinition {
       {/* Device Information Service */
        .type = BLE_GATT_SVC_TYPE_PRIMARY,
-       .uuid = (ble_uuid_t*) &immediateAlertServiceUuid,
+       .uuid = &immediateAlertServiceUuid.u,
        .characteristics = characteristicDefinition},
       {0},
     } {

--- a/src/components/ble/NavigationService.cpp
+++ b/src/components/ble/NavigationService.cpp
@@ -50,24 +50,18 @@ Pinetime::Controllers::NavigationService::NavigationService(Pinetime::System::Sy
   navProgressCharUuid.value[15] = navId[1];
 
   characteristicDefinition[0] = {
-    .uuid = (ble_uuid_t*) (&navFlagCharUuid), .access_cb = NAVCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+    .uuid = &navFlagCharUuid.u, .access_cb = NAVCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
 
-  characteristicDefinition[1] = {.uuid = (ble_uuid_t*) (&navNarrativeCharUuid),
-                                 .access_cb = NAVCallback,
-                                 .arg = this,
-                                 .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[2] = {.uuid = (ble_uuid_t*) (&navManDistCharUuid),
-                                 .access_cb = NAVCallback,
-                                 .arg = this,
-                                 .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
-  characteristicDefinition[3] = {.uuid = (ble_uuid_t*) (&navProgressCharUuid),
-                                 .access_cb = NAVCallback,
-                                 .arg = this,
-                                 .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+  characteristicDefinition[1] = {
+    .uuid = &navNarrativeCharUuid.u, .access_cb = NAVCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+  characteristicDefinition[2] = {
+    .uuid = &navManDistCharUuid.u, .access_cb = NAVCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
+  characteristicDefinition[3] = {
+    .uuid = &navProgressCharUuid.u, .access_cb = NAVCallback, .arg = this, .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ};
 
   characteristicDefinition[4] = {0};
 
-  serviceDefinition[0] = {.type = BLE_GATT_SVC_TYPE_PRIMARY, .uuid = (ble_uuid_t*) &navUuid, .characteristics = characteristicDefinition};
+  serviceDefinition[0] = {.type = BLE_GATT_SVC_TYPE_PRIMARY, .uuid = &navUuid.u, .characteristics = characteristicDefinition};
   serviceDefinition[1] = {0};
 
   m_progress = 0;
@@ -90,13 +84,13 @@ int Pinetime::Controllers::NavigationService::OnCommand(uint16_t conn_handle, ui
     data[notifSize] = '\0';
     os_mbuf_copydata(ctxt->om, 0, notifSize, data);
     char* s = (char*) &data[0];
-    if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &navFlagCharUuid) == 0) {
+    if (ble_uuid_cmp(ctxt->chr->uuid, &navFlagCharUuid.u) == 0) {
       m_flag = s;
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &navNarrativeCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &navNarrativeCharUuid.u) == 0) {
       m_narrative = s;
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &navManDistCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &navManDistCharUuid.u) == 0) {
       m_manDist = s;
-    } else if (ble_uuid_cmp(ctxt->chr->uuid, (ble_uuid_t*) &navProgressCharUuid) == 0) {
+    } else if (ble_uuid_cmp(ctxt->chr->uuid, &navProgressCharUuid.u) == 0) {
       m_progress = data[0];
     }
   }


### PR DESCRIPTION
Instead of casting the UUID object to the ble_uuid_t* used throughout
the NimBLE API just pass the address of the ble_uuid_t member that's at
the start of each of the UUID structs.