### PR TITLE
Fix LVGL touch

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -288,6 +288,7 @@ void DisplayApp::RunningState() {
     LoadApp(returnToApp, returnDirection);
   }
   lv_task_handler();
+  lvgl.ClearTouch();
 }
 
 void DisplayApp::StartApp(Apps app, DisplayApp::FullRefreshDirections direction) {

--- a/src/displayapp/LittleVgl.cpp
+++ b/src/displayapp/LittleVgl.cpp
@@ -172,12 +172,19 @@ void LittleVgl::SetNewTapEvent(uint16_t x, uint16_t y) {
   tapped = true;
 }
 
-bool LittleVgl::GetTouchPadInfo(lv_indev_data_t* ptr) {
-  if (tapped) {
-    ptr->point.x = tap_x;
-    ptr->point.y = tap_y;
-    ptr->state = LV_INDEV_STATE_PR;
+void LittleVgl::ClearTouch() {
+  if (touchProcessed) {
+    touchProcessed = false;
     tapped = false;
+  }
+}
+
+bool LittleVgl::GetTouchPadInfo(lv_indev_data_t* ptr) {
+  touchProcessed = true;
+  ptr->point.x = tap_x;
+  ptr->point.y = tap_y;
+  if (tapped) {
+    ptr->state = LV_INDEV_STATE_PR;
   } else {
     ptr->state = LV_INDEV_STATE_REL;
   }

--- a/src/displayapp/LittleVgl.h
+++ b/src/displayapp/LittleVgl.h
@@ -25,6 +25,7 @@ namespace Pinetime {
       bool GetTouchPadInfo(lv_indev_data_t* ptr);
       void SetFullRefresh(FullRefreshDirections direction);
       void SetNewTapEvent(uint16_t x, uint16_t y);
+      void ClearTouch();
 
     private:
       void InitDisplay();
@@ -55,6 +56,7 @@ namespace Pinetime {
       uint16_t tap_x = 0;
       uint16_t tap_y = 0;
       bool tapped = false;
+      bool touchProcessed = false;
     };
   }
 }


### PR DESCRIPTION
LVGL reads the touch position twice for some reason. The first time it is read, tapped is true and set to false. The second time it is read, tapped value is false, so LVGL thinks all touches are rapid taps.

The touch is read in `lv_task_handler()`, so by setting the value to false manually after it fixes the issue.

LVGL reads the touch point every 20ms so if `lv_task_handler()` is run early, the touch isn't read but it's still cleared. This is why the `touchProcessed` variable is needed.

This will fix #491 while #492 isn't ready.