### PR TITLE
Keep steps through reboots.

### DIFF
--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -67,6 +67,7 @@ namespace Pinetime {
       void Start();
       void PushMessage(Messages msg);
 
+      uint32_t SavingSteps(uint32_t steps);
       void OnButtonPushed();
       void OnTouchEvent();
 


### PR DESCRIPTION
Hi Dev Team.

Thank you for a fun and great project. I love to play around with it, and it's a solid system to run on my clock.

In this PR, I've tried to fix the issue with the step counter. Currently, we save the information inside the counter unit, which is reset if the clock ever reboots. Sadly the state of the current build is that you lose connection to the companion app and need to restart the clock to re-establish that connection.

So I wanted to persist the step count, and as we newly added a little file system, I thought some files with dates would solve this issue.

The code below creates a new file each day and saves the number of steps taken, and reset the step counter for each update. By doing this, we will remove the requirement to have an accurate count in the unit and keep the data preserved over boots.

I did not find a way to set the number to the unit or anything like that, so saving the value before reboots and restoring after seems not feasible at the moment.

This code might not be perfect as I've not written much C the last 20 years, but I've run the patch for more than 48 hours, and it seems to work.

As a side note, I want to assure you that I don't have any problems with critic and discussions, so if you have any suggestions or other comments, I'm here to learn and help out.

Thanks again, and keep up the great work.

Best regards
Daniel