### PR TITLE
Make README more friendly for new users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
-# PineTime
+## New to InfiniTime?
 
-[![Build PineTime Firmware](https://github.com/JF002/InfiniTime/workflows/Build%20PineTime%20Firmware/badge.svg?branch=master)](https://github.com/JF002/InfiniTime/actions)
-
-> The PineTime is a free and open source smartwatch capable of running custom-built open operating systems. Some of the notable features include a heart rate monitor, a week-long battery as well as a capacitive touch IPS display that is legible in direct sunlight. It is a fully community driven side-project, which means that it will ultimately be up to the developers and end-users to determine when they deem the PineTime ready to ship.
-
-> We envision the PineTime as a companion for not only your PinePhone but also for your favorite devices — any phone, tablet, or even PC.
-
-*https://www.pine64.org/pinetime/*
-
-The **Pinetime** smartwatch is built around the NRF52832 MCU (512KB Flash, 64KB RAM), a 240*240 LCD display driven by the ST7789 controller, an accelerometer, a heart rate sensor, and a vibration motor.
+ - [Getting started with InfiniTime 1.0 (quick user guide, update bootloader and InfiniTime,...)](doc/gettingStarted/gettingStarted-1.0.md)
+ - [Flash, upgrade (OTA), time synchronization,...](doc/gettingStarted/ota-gadgetbridge-nrfconnect.md)
 
 # InfiniTime
 
+[![Build PineTime Firmware](https://github.com/JF002/InfiniTime/workflows/Build%20PineTime%20Firmware/badge.svg?branch=master)](https://github.com/JF002/InfiniTime/actions)
+
 ![InfiniTime logo](images/infinitime-logo.jpg "InfiniTime Logo")
 
-The goal of this project is to design an open-source firmware for the Pinetime smartwatch :
+The goal of this project is to design an open-source firmware for the [Pinetime smartwatch](https://www.pine64.org/pinetime/) :
 
  - Code written in **modern C++**;
  - Build system based on **CMake**;
@@ -74,11 +69,6 @@ As of now, here is the list of achievements of this project:
  - [Bootloader](https://github.com/JF002/pinetime-mcuboot-bootloader) based on [MCUBoot](https://juullabs-oss.github.io/mcuboot/)
 
 ## Documentation
-
-### Getting started
-
- - [Getting started with InfiniTime 1.0 (quick user guide, update bootloader and InfiniTime,...)](doc/gettingStarted/gettingStarted-1.0.md)
- - [Flash, upgrade (OTA), time synchronization,...](doc/gettingStarted/ota-gadgetbridge-nrfconnect.md)
 
 ### Develop
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-## New to InfiniTime?
-
- - [Getting started with InfiniTime 1.0 (quick user guide, update bootloader and InfiniTime,...)](doc/gettingStarted/gettingStarted-1.0.md)
- - [Flash, upgrade (OTA), time synchronization,...](doc/gettingStarted/ota-gadgetbridge-nrfconnect.md)
-
 # InfiniTime
 
 [![Build PineTime Firmware](https://github.com/JF002/InfiniTime/workflows/Build%20PineTime%20Firmware/badge.svg?branch=master)](https://github.com/JF002/InfiniTime/actions)
@@ -16,6 +11,11 @@ The goal of this project is to design an open-source firmware for the [Pinetime 
  - Based on **[FreeRTOS 10.0.0](https://freertos.org)** real-time OS.
  - Using **[LittleVGL/LVGL 7](https://lvgl.io/)** as UI library...
  - ... and **[NimBLE 1.3.0](https://github.com/apache/mynewt-nimble)** as BLE stack.
+
+## New to InfiniTime?
+
+ - [Getting started with InfiniTime 1.0 (quick user guide, update bootloader and InfiniTime,...)](doc/gettingStarted/gettingStarted-1.0.md)
+ - [Flash, upgrade (OTA), time synchronization,...](doc/gettingStarted/ota-gadgetbridge-nrfconnect.md)
 
 ## Overview
 


### PR DESCRIPTION
Development documentation should be separated from user instructions.

Move getting started links higher and to a separate section so they're easier to find.
Replace section about PineTime with a link to pine64.org. Less information makes finding relevant information easier.

The "Using the firmware" (better name Companion apps) section should also be moved somewhere else, but where? Should they be in the same section as getting started?