### PR TITLE
Timer code cleanup

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -203,7 +203,7 @@ void DisplayApp::Refresh() {
       case Messages::TimerDone:
         if (currentApp == Apps::Timer) {
           auto* timer = static_cast<Screens::Timer*>(currentScreen.get());
-          timer->setDone();
+          timer->SetDone();
         } else {
           LoadApp(Apps::Timer, DisplayApp::FullRefreshDirections::Down);
         }

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -1,173 +1,123 @@
 #include "Timer.h"
-
-#include "Screen.h"
 #include "Symbols.h"
-#include "lvgl/lvgl.h"
-
 
 using namespace Pinetime::Applications::Screens;
 
-
 static void btnEventHandler(lv_obj_t* obj, lv_event_t event) {
-  Timer* screen = static_cast<Timer*>(obj->user_data);
+  auto* screen = static_cast<Timer*>(obj->user_data);
   screen->OnButtonEvent(obj, event);
 }
 
-void Timer::createButtons() {
-  btnMinutesUp = lv_btn_create(lv_scr_act(), nullptr);
-  btnMinutesUp->user_data = this;
-  lv_obj_set_event_cb(btnMinutesUp, btnEventHandler);
-  lv_obj_align(btnMinutesUp, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 20, -80);
-  lv_obj_set_height(btnMinutesUp, 40);
-  lv_obj_set_width(btnMinutesUp, 60);
-  txtMUp = lv_label_create(btnMinutesUp, nullptr);
-  lv_label_set_text(txtMUp, "+");
-  
-  btnMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
-  btnMinutesDown->user_data = this;
-  lv_obj_set_event_cb(btnMinutesDown, btnEventHandler);
-  lv_obj_align(btnMinutesDown, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 20, +40);
-  lv_obj_set_height(btnMinutesDown, 40);
-  lv_obj_set_width(btnMinutesDown, 60);
-  txtMDown = lv_label_create(btnMinutesDown, nullptr);
-  lv_label_set_text(txtMDown, "-");
-  
-  btnSecondsUp = lv_btn_create(lv_scr_act(), nullptr);
-  btnSecondsUp->user_data = this;
-  lv_obj_set_event_cb(btnSecondsUp, btnEventHandler);
-  lv_obj_align(btnSecondsUp, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 10, -80);
-  lv_obj_set_height(btnSecondsUp, 40);
-  lv_obj_set_width(btnSecondsUp, 60);
-  txtSUp = lv_label_create(btnSecondsUp, nullptr);
-  lv_label_set_text(txtSUp, "+");
-  
-  btnSecondsDown = lv_btn_create(lv_scr_act(), nullptr);
-  btnSecondsDown->user_data = this;
-  lv_obj_set_event_cb(btnSecondsDown, btnEventHandler);
-  lv_obj_align(btnSecondsDown, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 10, +40);
-  lv_obj_set_height(btnSecondsDown, 40);
-  lv_obj_set_width(btnSecondsDown, 60);
-  txtSDown = lv_label_create(btnSecondsDown, nullptr);
-  lv_label_set_text(txtSDown, "-");
-  
-}
+Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController) : Screen(app), timerController {timerController} {
 
-
-Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
-    : Screen(app),
-      running{true},
-      timerController{timerController} {
-  
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
-  
-  uint32_t seconds = timerController.GetTimeRemaining() / 1000;
-  lv_label_set_text_fmt(time, "%02lu:%02lu", seconds / 60, seconds % 60);
+  lv_label_set_text_static(time, "00:00");
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_CENTER, 0, -20);
 
-  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, -20);
-  
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;
   lv_obj_set_event_cb(btnPlayPause, btnEventHandler);
-  lv_obj_align(btnPlayPause, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -10);
-  lv_obj_set_height(btnPlayPause, 40);
-  txtPlayPause = lv_label_create(btnPlayPause, nullptr);
-  if (timerController.IsRunning()) {
-    lv_label_set_text(txtPlayPause, Symbols::pause);
-  } else {
-    lv_label_set_text(txtPlayPause, Symbols::play);
-    createButtons();
+  lv_obj_set_size(btnPlayPause, 120, 40);
+  lv_obj_align(btnPlayPause, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+
+  for (uint8_t i = 0; i < 4; i++) {
+    buttons[i] = lv_btn_create(lv_scr_act(), nullptr);
+    buttons[i]->user_data = this;
+    lv_obj_set_event_cb(buttons[i], btnEventHandler);
+    lv_obj_set_size(buttons[i], 60, 40);
+
+    static constexpr uint8_t extraArea = 10;
+    lv_obj_set_ext_click_area(buttons[i], extraArea, extraArea, extraArea, extraArea);
   }
-  
+
+  lv_obj_align(buttons[minUp], lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 20, -80);
+  lv_obj_set_style_local_value_str(buttons[minUp], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
+
+  lv_obj_align(buttons[minDown], lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 20, 40);
+  lv_obj_set_style_local_value_str(buttons[minDown], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
+
+  lv_obj_align(buttons[secUp], lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -20, -80);
+  lv_obj_set_style_local_value_str(buttons[secUp], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
+
+  lv_obj_align(buttons[secDown], lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -20, 40);
+  lv_obj_set_style_local_value_str(buttons[secDown], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
+
+  if (timerController.IsRunning()) {
+    SetButtonsHidden(true);
+    lv_obj_set_style_local_value_str(btnPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Symbols::pause);
+  } else {
+    lv_obj_set_style_local_value_str(btnPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Symbols::play);
+  }
+  Refresh();
 }
 
 Timer::~Timer() {
   lv_obj_clean(lv_scr_act());
-  
+}
+
+void Timer::UpdateTime() {
+  lv_label_set_text_fmt(time, "%02d:%02d", minutes, seconds);
 }
 
 bool Timer::Refresh() {
   if (timerController.IsRunning()) {
-    uint32_t seconds = timerController.GetTimeRemaining() / 1000;
-    lv_label_set_text_fmt(time, "%02lu:%02lu", seconds / 60, seconds % 60);
+    remainingTime = timerController.GetTimeRemaining() / 1000 + 1;
+    if (remainingTime.IsUpdated()) {
+      minutes = remainingTime.Get() / 60;
+      seconds = remainingTime.Get() % 60;
+      UpdateTime();
+    }
   }
   return running;
 }
 
-void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
-  if (event == LV_EVENT_CLICKED) {
-    if (obj == btnPlayPause) {
-      if (timerController.IsRunning()) {
-        lv_label_set_text(txtPlayPause, Symbols::play);
-        uint32_t seconds = timerController.GetTimeRemaining() / 1000;
-        minutesToSet = seconds / 60;
-        secondsToSet = seconds % 60;
-        timerController.StopTimer();
-        createButtons();
-        
-      } else if (secondsToSet + minutesToSet > 0) {
-        lv_label_set_text(txtPlayPause, Symbols::pause);
-        timerController.StartTimer((secondsToSet + minutesToSet * 60) * 1000);
-        
-        lv_obj_del(btnSecondsDown);
-        btnSecondsDown = nullptr;
-        lv_obj_del(btnSecondsUp);
-        btnSecondsUp = nullptr;
-        lv_obj_del(btnMinutesDown);
-        btnMinutesDown = nullptr;
-        lv_obj_del(btnMinutesUp);
-        btnMinutesUp = nullptr;
-        
-      }
-    } else {
-      if (!timerController.IsRunning()) {
-        if (obj == btnMinutesUp) {
-          if (minutesToSet >= 59) {
-            minutesToSet = 0;
-          } else {
-            minutesToSet++;
-          }
-          lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
-          
-        } else if (obj == btnMinutesDown) {
-          if (minutesToSet == 0) {
-            minutesToSet = 59;
-          } else {
-            minutesToSet--;
-          }
-          lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
-          
-        } else if (obj == btnSecondsUp) {
-          if (secondsToSet >= 59) {
-            secondsToSet = 0;
-          } else {
-            secondsToSet++;
-          }
-          lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
-          
-        } else if (obj == btnSecondsDown) {
-          if (secondsToSet == 0) {
-            secondsToSet = 59;
-          } else {
-            secondsToSet--;
-          }
-          lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
-          
-        }
-      }
-      
-    }
-    
+void Timer::SetButtonsHidden(bool hidden) {
+  for (uint8_t i = 0; i < 4; i++) {
+    lv_obj_set_hidden(buttons[i], hidden);
   }
-  
 }
 
+void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
+  if (event != LV_EVENT_CLICKED) {
+    return;
+  }
 
-void Timer::setDone() {
-  lv_label_set_text(time, "00:00");
-  lv_label_set_text(txtPlayPause, Symbols::play);
-  secondsToSet = 0;
-  minutesToSet = 0;
-  createButtons();
+  if (obj == btnPlayPause) {
+    if (timerController.IsRunning()) {
+      lv_obj_set_style_local_value_str(btnPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Symbols::play);
+      timerController.StopTimer();
+      SetButtonsHidden(false);
+    } else if (seconds + minutes > 0) {
+      lv_obj_set_style_local_value_str(btnPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Symbols::pause);
+      timerController.StartTimer((seconds + minutes * 60) * 1000);
+      SetButtonsHidden(true);
+    }
+  } else if (obj == buttons[minUp]) {
+    minutes = (minutes + 1) % 61;
+  } else if (obj == buttons[minDown]) {
+    if (minutes == 0) {
+      minutes = 60;
+    } else {
+      minutes--;
+    }
+  } else if (obj == buttons[secUp]) {
+    seconds = (seconds + 1) % 60;
+  } else if (obj == buttons[secDown]) {
+    if (seconds == 0) {
+      seconds = 59;
+    } else {
+      seconds--;
+    }
+  }
+  UpdateTime();
+}
+
+void Timer::SetDone() {
+  lv_obj_set_style_local_value_str(btnPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Symbols::play);
+  seconds = 0;
+  minutes = 0;
+  UpdateTime();
+  SetButtonsHidden(false);
 }

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -1,42 +1,39 @@
 #pragma once
 
 #include "Screen.h"
-#include "components/datetime/DateTimeController.h"
-#include "systemtask/SystemTask.h"
-#include "../LittleVgl.h"
-
 #include "components/timer/TimerController.h"
+#include "lvgl/lvgl.h"
 
-namespace Pinetime::Applications::Screens {
-  
-  
-  class Timer : public Screen {
-  public:
-    
-    enum class Modes {
-      Normal, Done
-    };
-    
-    Timer(DisplayApp* app, Controllers::TimerController& timerController);
-    
-    ~Timer() override;
-    
-    bool Refresh() override;
-    
-    void setDone();
-    
-    void OnButtonEvent(lv_obj_t* obj, lv_event_t event);
-  
-  private:
-    
-    bool running;
-    uint8_t secondsToSet = 0;
-    uint8_t minutesToSet = 0;
-    Controllers::TimerController& timerController;
-    
-    void createButtons();
-    
-    lv_obj_t* time, * msecTime, * btnPlayPause, * txtPlayPause, * btnMinutesUp, * btnMinutesDown, * btnSecondsUp, * btnSecondsDown, * txtMUp,
-        * txtMDown, * txtSUp, * txtSDown;
-  };
+namespace Pinetime {
+  namespace Applications {
+    namespace Screens {
+      class Timer : public Screen {
+      public:
+        enum {secUp, secDown, minUp, minDown};
+        Timer(DisplayApp* app, Controllers::TimerController& timerController);
+
+        ~Timer() override;
+
+        bool Refresh() override;
+
+        void SetDone();
+
+        void OnButtonEvent(lv_obj_t* obj, lv_event_t event);
+
+      private:
+        uint8_t seconds = 0;
+        uint8_t minutes = 0;
+        Controllers::TimerController& timerController;
+
+        DirtyValue<uint32_t> remainingTime;
+
+        void SetButtonsHidden(bool hidden);
+        void UpdateTime();
+
+        lv_obj_t* time;
+        lv_obj_t* btnPlayPause;
+        lv_obj_t* buttons[4];
+      };
+    }
+  }
 }


### PR DESCRIPTION
Reduced duplication.
Hide buttons instead of creating and deleting them.
Make the active area of buttons larger than what they look like. This makes the small buttons easier to press.
Fix alignment.
Small tweaks like minutes going up to 60 instead of 59.