### PR TITLE
Try to fix bootloop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <libraries/gpiote/app_gpiote.h>
 #include <libraries/timer/app_timer.h>
 #include <softdevice/common/nrf_sdh.h>
+#include <nrf_delay.h>
 
 // nimble
 #define min // workaround: nimble's min/max macros conflict with libstdc++
@@ -299,6 +300,14 @@ int main(void) {
   logger.Init();
 
   nrf_drv_clock_init();
+
+  // Unblock i2c?
+  nrf_gpio_cfg_output(pinTwiScl);
+  for (uint8_t i = 0; i < 16; i++) {
+    nrf_gpio_pin_toggle(pinTwiScl);
+    nrf_delay_us(5);
+  }
+  nrf_gpio_cfg_default(pinTwiScl);
 
   debounceTimer = xTimerCreate("debounceTimer", 200, pdFALSE, (void*) 0, DebounceTimerCallback);
   debounceChargeTimer = xTimerCreate("debounceTimerCharge", 200, pdFALSE, (void*) 0, DebounceTimerChargeCallback);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -308,6 +308,7 @@ int main(void) {
                NRF_GPIO_PIN_NOPULL,
                NRF_GPIO_PIN_S0D1,
                NRF_GPIO_PIN_NOSENSE);
+  nrf_gpio_pin_set(pinTwiScl);
   for (uint8_t i = 0; i < 16; i++) {
     nrf_gpio_pin_toggle(pinTwiScl);
     nrf_delay_us(5);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -302,7 +302,12 @@ int main(void) {
   nrf_drv_clock_init();
 
   // Unblock i2c?
-  nrf_gpio_cfg_output(pinTwiScl);
+  nrf_gpio_cfg(pinTwiScl,
+               NRF_GPIO_PIN_DIR_OUTPUT,
+               NRF_GPIO_PIN_INPUT_DISCONNECT,
+               NRF_GPIO_PIN_NOPULL,
+               NRF_GPIO_PIN_S0D1,
+               NRF_GPIO_PIN_NOSENSE);
   for (uint8_t i = 0; i < 16; i++) {
     nrf_gpio_pin_toggle(pinTwiScl);
     nrf_delay_us(5);


### PR DESCRIPTION
If the device is reset while the i2c bus is used, the bus can get blocked. I suspect this might be what is causing the bootloop issue. Here I implemented code to attempt to unblock the bus. I don't know if this will actually fix the issue.

Bootloop issue #317

https://www.i2c-bus.org/i2c-primer/analysing-obscure-problems/blocked-bus/