### PR TITLE
TwiMaster rework

### DIFF
--- a/src/drivers/TwiMaster.cpp
+++ b/src/drivers/TwiMaster.cpp
@@ -16,12 +16,14 @@ void TwiMaster::ConfigurePins() const {
   NRF_GPIO->PIN_CNF[params.pinScl] =
     (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
     (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) |
+    (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos) |
     (GPIO_PIN_CNF_DRIVE_S0D1 << GPIO_PIN_CNF_DRIVE_Pos) |
     (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos);
 
   NRF_GPIO->PIN_CNF[params.pinSda] =
     (GPIO_PIN_CNF_DIR_Input << GPIO_PIN_CNF_DIR_Pos) |
     (GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos) |
+    (GPIO_PIN_CNF_PULL_Disabled << GPIO_PIN_CNF_PULL_Pos) |
     (GPIO_PIN_CNF_DRIVE_S0D1 << GPIO_PIN_CNF_DRIVE_Pos) |
     (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos);
 }

--- a/src/drivers/TwiMaster.cpp
+++ b/src/drivers/TwiMaster.cpp
@@ -10,7 +10,6 @@ using namespace Pinetime::Drivers;
 
 TwiMaster::TwiMaster(NRF_TWIM_Type* module, uint32_t frequency, uint8_t pinSda, uint8_t pinScl)
   : module {module}, frequency {frequency}, pinSda {pinSda}, pinScl {pinScl} {
-  mutex = xSemaphoreCreateBinary();
 }
 
 void TwiMaster::ConfigurePins() const {
@@ -30,6 +29,10 @@ void TwiMaster::ConfigurePins() const {
 }
 
 void TwiMaster::Init() {
+  if (mutex == nullptr) {
+    mutex = xSemaphoreCreateBinary();
+  }
+
   ConfigurePins();
 
   twiBaseAddress = module;

--- a/src/drivers/TwiMaster.cpp
+++ b/src/drivers/TwiMaster.cpp
@@ -180,15 +180,10 @@ TwiMaster::ErrorCodes TwiMaster::Write(uint8_t deviceAddress, const uint8_t* dat
 }
 
 void TwiMaster::Sleep() {
-  while (twiBaseAddress->ENABLE != 0) {
-    twiBaseAddress->ENABLE = (TWIM_ENABLE_ENABLE_Disabled << TWIM_ENABLE_ENABLE_Pos);
-  }
-  nrf_gpio_cfg_default(6);
-  nrf_gpio_cfg_default(7);
+  twiBaseAddress->ENABLE = (TWIM_ENABLE_ENABLE_Disabled << TWIM_ENABLE_ENABLE_Pos);
 }
 
 void TwiMaster::Wakeup() {
-  ConfigurePins();
   twiBaseAddress->ENABLE = (TWIM_ENABLE_ENABLE_Enabled << TWIM_ENABLE_ENABLE_Pos);
 }
 

--- a/src/drivers/TwiMaster.h
+++ b/src/drivers/TwiMaster.h
@@ -8,16 +8,9 @@ namespace Pinetime {
   namespace Drivers {
     class TwiMaster {
     public:
-      enum class Modules { TWIM1 };
-      enum class Frequencies { Khz100, Khz250, Khz400 };
       enum class ErrorCodes { NoError, TransactionFailed };
-      struct Parameters {
-        uint32_t frequency;
-        uint8_t pinSda;
-        uint8_t pinScl;
-      };
 
-      TwiMaster(const Modules module, const Parameters& params);
+      TwiMaster(NRF_TWIM_Type* module, uint32_t frequency, uint8_t pinSda, uint8_t pinScl);
 
       void Init();
       ErrorCodes Read(uint8_t deviceAddress, uint8_t registerAddress, uint8_t* buffer, size_t size);
@@ -26,16 +19,18 @@ namespace Pinetime {
       void Sleep();
       void Wakeup();
 
-      void ConfigurePins() const;
-
     private:
       ErrorCodes Read(uint8_t deviceAddress, uint8_t* buffer, size_t size, bool stop);
       ErrorCodes Write(uint8_t deviceAddress, const uint8_t* data, size_t size, bool stop);
       void FixHwFreezed();
+      void ConfigurePins() const;
+
       NRF_TWIM_Type* twiBaseAddress;
       SemaphoreHandle_t mutex = nullptr;
-      const Modules module;
-      const Parameters params;
+      NRF_TWIM_Type* module;
+      uint32_t frequency;
+      uint8_t pinSda;
+      uint8_t pinScl;
       static constexpr uint8_t maxDataSize {16};
       static constexpr uint8_t registerSize {1};
       uint8_t internalBuffer[maxDataSize + registerSize];

--- a/src/drivers/TwiMaster.h
+++ b/src/drivers/TwiMaster.h
@@ -26,6 +26,8 @@ namespace Pinetime {
       void Sleep();
       void Wakeup();
 
+      void ConfigurePins() const;
+
     private:
       ErrorCodes Read(uint8_t deviceAddress, uint8_t* buffer, size_t size, bool stop);
       ErrorCodes Write(uint8_t deviceAddress, const uint8_t* data, size_t size, bool stop);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,9 +81,8 @@ Pinetime::Drivers::SpiNorFlash spiNorFlash {flashSpi};
 // The TWI device should work @ up to 400Khz but there is a HW bug which prevent it from
 // respecting correct timings. According to erratas heet, this magic value makes it run
 // at ~390Khz with correct timings.
-static constexpr uint32_t MaxTwiFrequencyWithoutHardwareBug {0x06200000};
-Pinetime::Drivers::TwiMaster twiMaster {Pinetime::Drivers::TwiMaster::Modules::TWIM1,
-                                        Pinetime::Drivers::TwiMaster::Parameters {MaxTwiFrequencyWithoutHardwareBug, pinTwiSda, pinTwiScl}};
+//static constexpr uint32_t MaxTwiFrequencyWithoutHardwareBug {0x06200000};
+Pinetime::Drivers::TwiMaster twiMaster {NRF_TWIM1, TWI_FREQUENCY_FREQUENCY_K250, pinTwiSda, pinTwiScl};
 Pinetime::Drivers::Cst816S touchPanel {twiMaster, touchPanelTwiAddress};
 #ifdef PINETIME_IS_RECOVERY
 static constexpr bool isFactory = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,8 +81,8 @@ Pinetime::Drivers::SpiNorFlash spiNorFlash {flashSpi};
 // The TWI device should work @ up to 400Khz but there is a HW bug which prevent it from
 // respecting correct timings. According to erratas heet, this magic value makes it run
 // at ~390Khz with correct timings.
-//static constexpr uint32_t MaxTwiFrequencyWithoutHardwareBug {0x06200000};
-Pinetime::Drivers::TwiMaster twiMaster {NRF_TWIM1, TWI_FREQUENCY_FREQUENCY_K250, pinTwiSda, pinTwiScl};
+static constexpr uint32_t MaxTwiFrequencyWithoutHardwareBug {0x06200000};
+Pinetime::Drivers::TwiMaster twiMaster {NRF_TWIM1, MaxTwiFrequencyWithoutHardwareBug, pinTwiSda, pinTwiScl};
 Pinetime::Drivers::Cst816S touchPanel {twiMaster, touchPanelTwiAddress};
 #ifdef PINETIME_IS_RECOVERY
 static constexpr bool isFactory = true;

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -219,7 +219,6 @@ void SystemTask::Work() {
           break;
         case Messages::GoToRunning:
           spi.Wakeup();
-          twiMaster.Wakeup();
 
           // Double Tap needs the touch screen to be in normal mode
           if (!settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::DoubleTap)) {
@@ -240,9 +239,7 @@ void SystemTask::Work() {
           isDimmed = false;
           break;
         case Messages::TouchWakeUp: {
-          twiMaster.Wakeup();
           auto touchInfo = touchPanel.GetTouchInfo();
-          twiMaster.Sleep();
           if (touchInfo.isTouch and ((touchInfo.gesture == Pinetime::Drivers::Cst816S::Gestures::DoubleTap and
                                       settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::DoubleTap)) or
                                      (touchInfo.gesture == Pinetime::Drivers::Cst816S::Gestures::SingleTap and
@@ -315,7 +312,6 @@ void SystemTask::Work() {
           if (!settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::DoubleTap)) {
             touchPanel.Sleep();
           }
-          twiMaster.Sleep();
 
           isSleeping = true;
           isGoingToSleep = false;
@@ -367,17 +363,12 @@ void SystemTask::UpdateMotion() {
   if (isSleeping && !settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist))
     return;
 
-  if (isSleeping)
-    twiMaster.Wakeup();
-
   if (stepCounterMustBeReset) {
     motionSensor.ResetStepCounter();
     stepCounterMustBeReset = false;
   }
 
   auto motionValues = motionSensor.Process();
-  if (isSleeping)
-    twiMaster.Sleep();
 
   motionController.IsSensorOk(motionSensor.IsOk());
   motionController.Update(motionValues.x, motionValues.y, motionValues.z, motionValues.steps);


### PR DESCRIPTION
Made using TwiMaster simpler. The bus is simply enabled on each read/write and disabled when done. There's no need to think about or control the state outside of TwiMaster. I don't know if this is more expensive, but it seems to work just fine.

Internal pullups were enabled. They're unnecessary because external pullups are used.

~~This will fix the freezing issue in #492 so I can finally move forwards with it.~~

Sleep() and Wakeup() can almost be made private, but there's still this piece of code in SystemTask I'm not brave enough to touch.

```
  // Reset the TWI device because the motion sensor chip most probably crashed it...
  twiMaster.Sleep();
  twiMaster.Init();
```