### PR TITLE
fix Github Action build Firmware

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Embedded Arm Toolchain arm-none-eabi-gcc
         if:   steps.cache-toolchain.outputs.cache-hit != 'true'  # Install toolchain if not found in cache
-        uses: fiam/arm-none-eabi-gcc@v1.0.2
+        uses: fiam/arm-none-eabi-gcc@v1.0.4
         with:
           # GNU Embedded Toolchain for Arm release name, in the V-YYYY-qZ format (e.g. "9-2019-q4")
           release: 9-2020-q2
@@ -83,10 +83,16 @@ jobs:
         if:   steps.cache-mcuboot.outputs.cache-hit != 'true'  # Install MCUBoot if not found in cache
         run:  |
           cd ${{ runner.temp }}
-          git clone --branch v1.5.0 https://github.com/JuulLabs-OSS/mcuboot
+          git clone --branch v1.5.0 https://github.com/mcu-tools/mcuboot
 
       - name: Install imgtool dependencies
-        run:  pip3 install --user -r ${{ runner.temp }}/mcuboot/scripts/requirements.txt
+        run:  |
+          pip3 install --user -r ${{ runner.temp }}/mcuboot/scripts/requirements.txt
+
+      # cbor is a dependency that is not currently included in mcuboot requirements.txt
+      - name: Install imgtool dependencies (cbor)
+        run:  |
+          pip3 install --user cbor
 
       - name: Install adafruit-nrfutil
         run:  |
@@ -99,6 +105,8 @@ jobs:
 
       - name: Checkout source files
         uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Show files
         run:  set ; pwd ; ls -l
@@ -110,7 +118,7 @@ jobs:
         run:  |
           mkdir -p build
           cd build
-          cmake -DARM_NONE_EABI_TOOLCHAIN_PATH=${{ runner.temp }}/arm-none-eabi -DNRF5_SDK_PATH=${{ runner.temp }}/nrf5_sdk -DUSE_OPENOCD=1 ../
+          cmake -DARM_NONE_EABI_TOOLCHAIN_PATH=${{ runner.temp }}/arm-none-eabi -DNRF5_SDK_PATH=${{ runner.temp }}/nrf5_sdk -DUSE_OPENOCD=1 -DBUILD_DFU=1 ../
 
         #########################################################################################
         # Make and Upload DFU Package
@@ -125,19 +133,10 @@ jobs:
           cd build
           make pinetime-mcuboot-app
 
-      - name: Create firmware image
+      - name: Unzip DFU package
         run:  |
-          # The generated firmware binary looks like "pinetime-mcuboot-app-0.8.2.bin"
-          ls -l build/src/pinetime-mcuboot-app*.bin
-          ${{ runner.temp }}/mcuboot/scripts/imgtool.py create --align 4 --version 1.0.0 --header-size 32 --slot-size 475136 --pad-header build/src/pinetime-mcuboot-app*.bin build/src/pinetime-mcuboot-app-img.bin
-          ${{ runner.temp }}/mcuboot/scripts/imgtool.py verify build/src/pinetime-mcuboot-app-img.bin
-
-      - name: Create DFU package
-        run:  |
-          ~/.local/bin/adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/src/pinetime-mcuboot-app-img.bin build/src/pinetime-mcuboot-app-dfu.zip
-          unzip -v build/src/pinetime-mcuboot-app-dfu.zip
           # Unzip the package because Upload Artifact will zip up the files
-          unzip build/src/pinetime-mcuboot-app-dfu.zip -d build/src/pinetime-mcuboot-app-dfu
+          unzip build/src/pinetime-mcuboot-app-dfu*.zip -d build/src/pinetime-mcuboot-app-dfu
 
       - name: Upload DFU package
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,16 +83,11 @@ jobs:
         if:   steps.cache-mcuboot.outputs.cache-hit != 'true'  # Install MCUBoot if not found in cache
         run:  |
           cd ${{ runner.temp }}
-          git clone --branch v1.5.0 https://github.com/mcu-tools/mcuboot
+          git clone --branch v1.7.2 https://github.com/mcu-tools/mcuboot
 
       - name: Install imgtool dependencies
         run:  |
           pip3 install --user -r ${{ runner.temp }}/mcuboot/scripts/requirements.txt
-
-      # cbor is a dependency that is not currently included in mcuboot requirements.txt
-      - name: Install imgtool dependencies (cbor)
-        run:  |
-          pip3 install --user cbor
 
       - name: Install adafruit-nrfutil
         run:  |


### PR DESCRIPTION
This fixes the github Action for Firmware building.
It is largely based on pull request #294 from nanch (which I critically reviewed).

There are a few small differences:
- Instead of using ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true' for step "Install Embedded Arm Toolchain arm-none-eabi-gcc" instead the most current version (1.0.4) of fiam/arm-none-eabi-gcc is used, this now again works with the github automation (as I find this solution to be cleaner).
- Using cmake option -DBUILD_DFU=1 to build DFU and therefore removing the obsolete step
- Removing the unecessary step to build the firmware as this is also included in cmake and changing the unzip step to use the created zip-file. 

This is my first pull request ever, in case I should do something different next time, please provide me with feedback.
Thanks