### PR TITLE
WIP: Improve wake-up time

### DIFF
--- a/src/drivers/Cst816s.cpp
+++ b/src/drivers/Cst816s.cpp
@@ -19,8 +19,8 @@ Cst816S::Cst816S(TwiMaster& twiMaster, uint8_t twiAddress) : twiMaster {twiMaste
 
 void Cst816S::Init() {
   nrf_gpio_cfg_output(pinReset);
-  nrf_gpio_pin_set(pinReset);
-  vTaskDelay(50);
+  //nrf_gpio_pin_set(pinReset);
+  //vTaskDelay(5);
   nrf_gpio_pin_clear(pinReset);
   vTaskDelay(5);
   nrf_gpio_pin_set(pinReset);

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -171,15 +171,15 @@ void St7789::Sleep() {
 void St7789::Wakeup() {
   nrf_gpio_cfg_output(pinDataCommand);
   // TODO why do we need to reset the controller?
-  HardwareReset();
-  SoftwareReset();
+  //HardwareReset();
+  //SoftwareReset();
   SleepOut();
-  ColMod();
-  MemoryDataAccessControl();
-  ColumnAddressSet();
-  RowAddressSet();
-  DisplayInversionOn();
-  NormalModeOn();
+  //ColMod();
+  //MemoryDataAccessControl();
+  //ColumnAddressSet();
+  //RowAddressSet();
+  //DisplayInversionOn();
+  //NormalModeOn();
   VerticalScrollStartAddress(verticalScrollingStartAddress);
   DisplayOn();
   NRF_LOG_INFO("[LCD] Wakeup")


### PR DESCRIPTION
Hi, I've noticed that wake-up time is not as fast as I would expect. So I did a little investigation and would like to discuss what could be improved.
When I use button or wake-up on wrist, then there is really perceptible delay between button press and the moment I can read time. This delay slightly affects the wake-up on wrist, because when the logic detects the wrist motion, it is starting and you still moving your wrist up to wake it up, but this is not necessary since the movement was already sensed.

So I connected button and LCD backlight to the oscilloscope and measured the delays and different possible improvements.

### Double-tap wake-up configuration
Current wake-up time differs in one configuration option - Double tap wake-up. This is turned on after reboot. When this is on, then wake-up is faster (no delays). When you turn double-tap off, then the touch constroller is completely put to sleep, and only 50ms reset pulse + more delays will initialize it. So wake-up with double-tap off adds at least additional 115ms (improvements below).

## Current Wake-up times
Double-tap enabled 400-600 ms
Double-tap disabled 600-750 ms

## Analysis of functions and delays
This analysis does not take into account communication delays, its just differnet delays commands in the code.
Functions which are in `case Messages::GoToRunning:` in SystemTask.cpp have these delays inside:

SPI - no delays

twiMaster - no delays

CST touch init - **only when double tap is off**
50+5+50+5+5 = **115ms**

SPI NOR flash - no delays

LCD
HardwareReset 10 ms
SoftwareReset reset 150ms
ColMod 10ms
DisplayInversionOn 10ms
NormalModeOn 10ms
= **190ms** in delays

## Improvements

### Touch controller 
**applies only when double tap is off**

```
void Cst816S::Init() {
  nrf_gpio_cfg_output(pinReset);
  nrf_gpio_pin_set(pinReset);
  vTaskDelay(50);
  nrf_gpio_pin_clear(pinReset);
  vTaskDelay(5);
  nrf_gpio_pin_set(pinReset);
  vTaskDelay(50);

  // Wake the touchpanel up
  uint8_t dummy;
  twiMaster.Read(twiAddress, 0x15, &dummy, 1);
  vTaskDelay(5);
  twiMaster.Read(twiAddress, 0xa7, &dummy, 1);
  vTaskDelay(5);
```

The first `nrf_gpio_pin_set(pinReset);` with 50ms delay really is not necessary. So this saves us 50 ms just there.
The second 50ms delay after reset is tricky. No info in datasheet, just other drivers also have 50ms..  I keep it for now but it seemed like 20-30ms was too little and touch sometimes initialized much later and missed the first swipe. So it might not worth the risk for 10-20 ms. Let's keep it.

**So we gained 50 ms**

### LCD 

JF002 had this comment in `St7789::Wakeup()`:
`// TODO why do we need to reset the controller?`

So I removed both SW and HW reset. Kept `SleepOut();`.

And because we do not reset controller, then we might remove bunch of other calls which have 10 ms delays in it.
And it works perfectly fine without resets. However this needs to be tested by others. I have no deep knowledge why the code used resets in the first place.

**Bonus points: 190 ms**

## Final measurements

So we improved touch controller reset, but that's just the edge case when someone disables double tap wake-up. But the LCD really improved timing.

Previously we 400-600 ms wake up time. Now we have 200-300ms wake-up time.
This feels muuuch better and it feels like the lcd turns on instantly.

## More ideas?
I was thinking if we can shuffle the functions in wake-up state machine. For example turn on LCD first and then activate touch and SPI flash. But this might not be possible because then you might miss the first swipe gesture (tested), or when I2C or SPI flash is disabled, then the screen might not display some data from flash...

Current PR is safe and complete, so you can merge it and test how it works for you. I just let this as WIP DRAFT PR in case we might figure more improvements.

Thanks for feedback and other ideas.