### PR TITLE
Fix music app buttons

### DIFF
--- a/src/displayapp/screens/Music.cpp
+++ b/src/displayapp/screens/Music.cpp
@@ -292,7 +292,7 @@ bool Music::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
       return true;
     }
     default: {
-      return true;
+      return false;
     }
   }
 }


### PR DESCRIPTION
Music OnTouchEvent() also returned the wrong value, which caused the touch to get ignored after #426.

Fixes #599.