### PR TITLE
add different virbrations tunes/patterns support as bzzzt for 50 or 35ms is boring

### DIFF
--- a/src/components/motor/MotorController.h
+++ b/src/components/motor/MotorController.h
@@ -7,19 +7,48 @@
 namespace Pinetime {
   namespace Controllers {
     static constexpr uint8_t pinMotor = 16;
-
+    
+    
     class MotorController {
+    
+
     public:
+      enum TuneType : uint8_t {
+        NOTIFICATION,
+        SHORT,
+        RING,
+        STOP
+      };
+
       MotorController(Controllers::Settings& settingsController);
       void Init();
       void RunForDuration(uint8_t motorDuration);
       void StartRinging();
       static void StopRinging();
+      void VibrateTune(TuneType tune);
 
     private:
-      static void Ring(void* p_context);
+
+    private:
+      struct Tune { 
+        uint8_t tune;
+        uint8_t length;
+        uint8_t tempo;
+      };
       Controllers::Settings& settingsController;
-      static void StopMotor(void* p_context);
+      static TuneType runningTune;
+      static uint8_t step;
+
+      static constexpr Tune tunes[] =  {
+        [TuneType::NOTIFICATION] = {.tune = 0x29, .length = 6, .tempo = 50},
+        [TuneType::SHORT] = {.tune = 0x01, .length = 2, .tempo = 35},
+        [TuneType::RING] = {.tune = 0x0f, .length = 8, .tempo = 50},
+        [TuneType::STOP] = {.tune = 0x00, .length = 0, .tempo = 0},
+      };
+
+      static void Vibrate(void* p_context);
+      static void Ring(void* p_context);
+    
     };
   }
 }

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -40,7 +40,7 @@ Notifications::Notifications(DisplayApp* app,
     if (notification.category == Controllers::NotificationManager::Categories::IncomingCall) {
       motorController.StartRinging();
     } else {
-      motorController.RunForDuration(35);
+      motorController.VibrateTune(Controllers::MotorController::TuneType::NOTIFICATION);
       timeoutLine = lv_line_create(lv_scr_act(), nullptr);
 
       lv_obj_set_style_local_line_width(timeoutLine, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, 3);

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -325,7 +325,7 @@ void SystemTask::Work() {
           stepCounterMustBeReset = true;
           break;
         case Messages::OnChargingEvent:
-          motorController.RunForDuration(15);
+          motorController.VibrateTune(motorController.TuneType::SHORT);
 	  // Battery level is updated on every message - there's no need to do anything
           break;
 


### PR DESCRIPTION
Things attempted

- refactor, so that the different vibration types can be declared in one place
- support different tunes/patterns,  not only durations
- try to conserve memory
- preserve motorController.RunForDuration(duration) functionality for manual access if needed 