### PR TITLE
Ignore vibration status in metronome

### DIFF
--- a/src/components/motor/MotorController.cpp
+++ b/src/components/motor/MotorController.cpp
@@ -25,8 +25,8 @@ void MotorController::Ring(void* p_context) {
   motorController->RunForDuration(50);
 }
 
-void MotorController::RunForDuration(uint8_t motorDuration) {
-  if (settingsController.GetVibrationStatus() == Controllers::Settings::Vibration::OFF) {
+void MotorController::RunForDuration(uint8_t motorDuration, bool force) {
+  if (!force && settingsController.GetVibrationStatus() == Controllers::Settings::Vibration::OFF) {
     return;
   }
 

--- a/src/components/motor/MotorController.h
+++ b/src/components/motor/MotorController.h
@@ -12,7 +12,7 @@ namespace Pinetime {
     public:
       MotorController(Controllers::Settings& settingsController);
       void Init();
-      void RunForDuration(uint8_t motorDuration);
+      void RunForDuration(uint8_t motorDuration, bool force = false);
       void StartRinging();
       static void StopRinging();
 

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -83,9 +83,9 @@ bool Metronome::Refresh() {
       counter--;
       if (counter == 0) {
         counter = bpb;
-        motorController.RunForDuration(90);
+        motorController.RunForDuration(90, true);
       } else {
-        motorController.RunForDuration(30);
+        motorController.RunForDuration(30, true);
       }
     }
   }


### PR DESCRIPTION
I feel the metronome should either ignore the motor status or notify the user if the motor is disabled.

This MR adds a force option to `RunForDuration` which causes it to ignore the vibration status, and forces vibration for the metronome.