### PR TITLE
Silent mode enabled rather than vibration enabled

### DIFF
--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -81,18 +81,18 @@ QuickSettings::QuickSettings(Pinetime::Applications::DisplayApp* app,
   lv_obj_set_event_cb(btn3, ButtonEventHandler);
   lv_btn_set_checkable(btn3, true);
   lv_obj_add_style(btn3, LV_BTN_PART_MAIN, &btn_style);
-  lv_obj_set_style_local_bg_color(btn3, LV_BTN_PART_MAIN, LV_STATE_CHECKED, LV_COLOR_GREEN);
+  lv_obj_set_style_local_bg_color(btn3, LV_BTN_PART_MAIN, LV_STATE_CHECKED, LV_COLOR_RED);
   lv_obj_set_size(btn3, buttonWidth, buttonHeight);
   lv_obj_align(btn3, nullptr, LV_ALIGN_IN_BOTTOM_LEFT, buttonXOffset, 0);
 
   btn3_lvl = lv_label_create(btn3, nullptr);
   lv_obj_set_style_local_text_font(btn3_lvl, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_sys_48);
 
-  if (settingsController.GetVibrationStatus() == Controllers::Settings::Vibration::ON) {
+  if (settingsController.GetVibrationStatus() == Controllers::Settings::Vibration::OFF) {
     lv_obj_add_state(btn3, LV_STATE_CHECKED);
-    lv_label_set_text_static(btn3_lvl, Symbols::notificationsOn);
-  } else {
     lv_label_set_text_static(btn3_lvl, Symbols::notificationsOff);
+  } else {
+    lv_label_set_text_static(btn3_lvl, Symbols::notificationsOn);
   }
 
   btn4 = lv_btn_create(lv_scr_act(), nullptr);
@@ -142,12 +142,12 @@ void QuickSettings::OnButtonEvent(lv_obj_t* object, lv_event_t event) {
   } else if (object == btn3 && event == LV_EVENT_VALUE_CHANGED) {
 
     if (lv_obj_get_state(btn3, LV_BTN_PART_MAIN) & LV_STATE_CHECKED) {
+      settingsController.SetVibrationStatus(Controllers::Settings::Vibration::OFF);
+      lv_label_set_text_static(btn3_lvl, Symbols::notificationsOff);
+    } else {
       settingsController.SetVibrationStatus(Controllers::Settings::Vibration::ON);
       motorController.RunForDuration(35);
       lv_label_set_text_static(btn3_lvl, Symbols::notificationsOn);
-    } else {
-      settingsController.SetVibrationStatus(Controllers::Settings::Vibration::OFF);
-      lv_label_set_text_static(btn3_lvl, Symbols::notificationsOff);
     }
 
   } else if (object == btn4 && event == LV_EVENT_PRESSED) {


### PR DESCRIPTION
This might just be my personal preference but I think this is more intuitive as a silent mode toggle, rather than a vibration toggle.

<img src="https://user-images.githubusercontent.com/334272/131121831-de78d3d8-d8bb-469c-9ee8-c312b73cfe01.jpg" width="256px" alt="Silence disabled / Vibration enabled"> <img src="https://user-images.githubusercontent.com/334272/131121833-9274cbfd-3a3c-4f44-909c-efda9dc862fb.jpg" width="256px" alt="Silence enabled / Vibration disabled">

left: silent mode is off (watch will vibrate), right: silent mode is on (watch will not vibrate)