### PR TITLE
Move PineTimeStyle settings up

### DIFF
--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -50,8 +50,8 @@ std::unique_ptr<Screen> Settings::CreateScreen2() {
   std::array<Screens::List::Applications, 4> applications {{
     {Symbols::shoe, "Steps", Apps::SettingSteps},
     {Symbols::batteryHalf, "Battery", Apps::BatteryInfo},
+    {Symbols::paintbrush, "PTS Colors", Apps::SettingPineTimeStyle},
     {Symbols::check, "Firmware", Apps::FirmwareValidation},
-    {Symbols::list, "About", Apps::SysInfo},
   }};
 
   return std::make_unique<Screens::List>(1, 3, app, settingsController, applications);
@@ -60,7 +60,7 @@ std::unique_ptr<Screen> Settings::CreateScreen2() {
 std::unique_ptr<Screen> Settings::CreateScreen3() {
 
   std::array<Screens::List::Applications, 4> applications {{
-    {Symbols::paintbrush, "PTS Colors", Apps::SettingPineTimeStyle},
+    {Symbols::list, "About", Apps::SysInfo},
     {Symbols::none, "None", Apps::None},
     {Symbols::none, "None", Apps::None},
     {Symbols::none, "None", Apps::None},


### PR DESCRIPTION
It's now over the 'Firmware' entry. It make sense to have 'Firmware' and 'About' the 2 last entries as they are the least used in my opinion.