### PR TITLE
Toggle notifications only, keep vibrations.

### DIFF
--- a/src/components/ble/NotificationManager.cpp
+++ b/src/components/ble/NotificationManager.cpp
@@ -79,14 +79,6 @@ bool NotificationManager::AreNewNotificationsAvailable() {
   return newNotification;
 }
 
-bool NotificationManager::IsVibrationEnabled() {
-  return vibrationEnabled;
-}
-
-void NotificationManager::ToggleVibrations() {
-  vibrationEnabled = !vibrationEnabled;
-}
-
 bool NotificationManager::ClearNewNotificationFlag() {
   return newNotification.exchange(false);
 }

--- a/src/components/ble/NotificationManager.h
+++ b/src/components/ble/NotificationManager.h
@@ -44,8 +44,6 @@ namespace Pinetime {
       Notification GetPrevious(Notification::Id id);
       bool ClearNewNotificationFlag();
       bool AreNewNotificationsAvailable();
-      bool IsVibrationEnabled();
-      void ToggleVibrations();
 
       static constexpr size_t MaximumMessageSize() {
         return MessageSize;
@@ -60,7 +58,6 @@ namespace Pinetime {
       uint8_t writeIndex = 0;
       bool empty = true;
       std::atomic<bool> newNotification {false};
-      bool vibrationEnabled = true;
     };
   }
 }

--- a/src/components/motor/MotorController.cpp
+++ b/src/components/motor/MotorController.cpp
@@ -8,9 +8,6 @@ APP_TIMER_DEF(longVibTimer);
 
 using namespace Pinetime::Controllers;
 
-MotorController::MotorController(Controllers::Settings& settingsController) : settingsController {settingsController} {
-}
-
 void MotorController::Init() {
   nrf_gpio_cfg_output(pinMotor);
   nrf_gpio_pin_set(pinMotor);
@@ -26,18 +23,11 @@ void MotorController::Ring(void* p_context) {
 }
 
 void MotorController::RunForDuration(uint8_t motorDuration) {
-  if (settingsController.GetVibrationStatus() == Controllers::Settings::Vibration::OFF) {
-    return;
-  }
-
   nrf_gpio_pin_clear(pinMotor);
   app_timer_start(shortVibTimer, APP_TIMER_TICKS(motorDuration), nullptr);
 }
 
 void MotorController::StartRinging() {
-  if (settingsController.GetVibrationStatus() == Controllers::Settings::Vibration::OFF) {
-    return;
-  }
   Ring(this);
   app_timer_start(longVibTimer, APP_TIMER_TICKS(1000), this);
 }

--- a/src/components/motor/MotorController.h
+++ b/src/components/motor/MotorController.h
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include "app_timer.h"
-#include "components/settings/Settings.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -10,7 +9,8 @@ namespace Pinetime {
 
     class MotorController {
     public:
-      MotorController(Controllers::Settings& settingsController);
+      MotorController() = default;
+
       void Init();
       void RunForDuration(uint8_t motorDuration);
       void StartRinging();
@@ -18,7 +18,6 @@ namespace Pinetime {
 
     private:
       static void Ring(void* p_context);
-      Controllers::Settings& settingsController;
       static void StopMotor(void* p_context);
     };
   }

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -11,7 +11,7 @@ namespace Pinetime {
     class Settings {
     public:
       enum class ClockType : uint8_t { H24, H12 };
-      enum class Vibration : uint8_t { ON, OFF };
+      enum class Notification : uint8_t { ON, OFF };
       enum class WakeUpMode : uint8_t {
         SingleTap = 0,
         DoubleTap = 1,
@@ -93,14 +93,14 @@ namespace Pinetime {
         return settings.clockType;
       };
 
-      void SetVibrationStatus(Vibration status) {
-        if (status != settings.vibrationStatus) {
+      void SetNotificationStatus(Notification status) {
+        if (status != settings.notificationStatus) {
           settingsChanged = true;
         }
-        settings.vibrationStatus = status;
+        settings.notificationStatus = status;
       };
-      Vibration GetVibrationStatus() const {
-        return settings.vibrationStatus;
+      Notification GetNotificationStatus() const {
+        return settings.notificationStatus;
       };
 
       void SetScreenTimeOut(uint32_t timeout) {
@@ -170,7 +170,7 @@ namespace Pinetime {
         uint32_t screenTimeOut = 15000;
 
         ClockType clockType = ClockType::H24;
-        Vibration vibrationStatus = Vibration::ON;
+        Notification notificationStatus = Notification::ON;
 
         uint8_t clockFace = 0;
 

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -129,10 +129,6 @@ bool Notifications::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
                                                        alertNotificationService);
     }
       return true;
-    case Pinetime::Applications::TouchEvents::LongTap: {
-      // notificationManager.ToggleVibrations();
-      return true;
-    }
     default:
       return false;
   }

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -88,7 +88,7 @@ QuickSettings::QuickSettings(Pinetime::Applications::DisplayApp* app,
   btn3_lvl = lv_label_create(btn3, nullptr);
   lv_obj_set_style_local_text_font(btn3_lvl, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_sys_48);
 
-  if (settingsController.GetVibrationStatus() == Controllers::Settings::Vibration::ON) {
+  if (settingsController.GetNotificationStatus() == Controllers::Settings::Notification::ON) {
     lv_obj_add_state(btn3, LV_STATE_CHECKED);
     lv_label_set_text_static(btn3_lvl, Symbols::notificationsOn);
   } else {
@@ -142,11 +142,11 @@ void QuickSettings::OnButtonEvent(lv_obj_t* object, lv_event_t event) {
   } else if (object == btn3 && event == LV_EVENT_VALUE_CHANGED) {
 
     if (lv_obj_get_state(btn3, LV_BTN_PART_MAIN) & LV_STATE_CHECKED) {
-      settingsController.SetVibrationStatus(Controllers::Settings::Vibration::ON);
+      settingsController.SetNotificationStatus(Controllers::Settings::Notification::ON);
       motorController.RunForDuration(35);
       lv_label_set_text_static(btn3_lvl, Symbols::notificationsOn);
     } else {
-      settingsController.SetVibrationStatus(Controllers::Settings::Vibration::OFF);
+      settingsController.SetNotificationStatus(Controllers::Settings::Notification::OFF);
       lv_label_set_text_static(btn3_lvl, Symbols::notificationsOff);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,7 @@ Pinetime::Controllers::TouchHandler touchHandler(touchPanel, lvgl);
 
 Pinetime::Controllers::FS fs {spiNorFlash};
 Pinetime::Controllers::Settings settingsController {fs};
-Pinetime::Controllers::MotorController motorController {settingsController};
+Pinetime::Controllers::MotorController motorController {};
 
 
 Pinetime::Applications::DisplayApp displayApp(lcd,

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -263,10 +263,12 @@ void SystemTask::Work() {
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::UpdateDateTime);
           break;
         case Messages::OnNewNotification:
-          if (isSleeping && !isWakingUp) {
-            GoToRunning();
+          if (settingsController.GetNotificationStatus() == Pinetime::Controllers::Settings::Notification::ON) {
+            if (isSleeping && !isWakingUp) {
+              GoToRunning();
+            }
+            displayApp.PushMessage(Pinetime::Applications::Display::Messages::NewNotification);
           }
-          displayApp.PushMessage(Pinetime::Applications::Display::Messages::NewNotification);
           break;
         case Messages::OnTimerDone:
           if (isSleeping && !isWakingUp) {


### PR DESCRIPTION
This makes the button with a bell icon disable notifications instead of disabling vibrations. This makes Timer and Metronome work correctly when notifications are disabled. When disabled, the watch won't wake up when receiving notifications and will show an icon on the watch face indicating a new notification. This was always present, but wasn't ever shown.

![notif](https://user-images.githubusercontent.com/37774658/132979185-5ff31a59-526e-4af7-aab9-c6401866a8a8.jpg)

Fixes #637
Related to #610, because now the notification screen won't pop up when notifications have been disabled.
Inspred by #662 so that we wouldn't need a `StartRingingDisregardSettings()` function.