### PR TITLE
Remove unused include in MotoController.h

### DIFF
--- a/src/components/motor/MotorController.h
+++ b/src/components/motor/MotorController.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include "app_timer.h"
 #include "components/settings/Settings.h"
 
 namespace Pinetime {


### PR DESCRIPTION
Remove the unused include `app_timer.h` in `MotorController.h`

It still compiles. I haven't tested to flash it, as I only have a sealed watch, and I'm afraid to brick it