### PR TITLE
Fix unsigned/signed comparison warning in Metronome.cpp

### DIFF
--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -78,7 +78,7 @@ Metronome::~Metronome() {
 
 void Metronome::Refresh() {
   if (metronomeStarted) {
-    if (xTaskGetTickCount() - startTime > 60 * configTICK_RATE_HZ / bpm) {
+    if (xTaskGetTickCount() - startTime > 60u * configTICK_RATE_HZ / static_cast<uint16_t>(bpm)) {
       startTime += 60 * configTICK_RATE_HZ / bpm;
       counter--;
       if (counter == 0) {


### PR DESCRIPTION
`xTaskGetTickCount()` returns a `TickType_t`, which is defined as an
`uint32_t`. This is compared to the `bpm` variable, which is a `int16_t`
in the range of 40 to 220 as defined in the constructor.

```cpp
  lv_arc_set_range(bpmArc, 40, 220);
```

Just to be sure also add an assert that `bpm` is greater than 0, as this
would result in a division by zero or negative values, which would
unintentionally underflow to a very large number.

---

Not flashed, I have only a sealed watch and I'm afraid of bricking it