### PR TITLE
Fix advertising packets stopping after 18.2 hours

### DIFF
--- a/src/libs/mynewt-nimble/nimble/controller/include/controller/ble_ll_rfmgmt.h
+++ b/src/libs/mynewt-nimble/nimble/controller/include/controller/ble_ll_rfmgmt.h
@@ -51,7 +51,7 @@ static inline void ble_ll_rfmgmt_reset(void) { }
 static inline void ble_ll_rfmgmt_scan_changed(bool e, uint32_t n) { }
 static inline void ble_ll_rfmgmt_sched_changed(struct ble_ll_sched_item *f) { }
 static inline void ble_ll_rfmgmt_release(void) { }
-static inline uint32_t ble_ll_rfmgmt_enable_now(void) { return 0; }
+static inline uint32_t ble_ll_rfmgmt_enable_now(void) { return os_cputime_get32(); }
 static inline bool ble_ll_rfmgmt_is_enabled(void) { return true; }
 
 #endif


### PR DESCRIPTION
The previous code always returned 0 (when `MYNEWT_VAL_BLE_LL_RFMGMT_ENABLE_TIME` is not defined), rather than a time near to the current tick.  This caused an issue in at least one place: `ble_ll_adv_sm_start()`, where the calculation of `delta` overflows when the system timer is at 0x80000000 or above -- causing an incorrect, huge adjustment to be made to the scheduled time, ultimately stopping adverts from being sent.

This returns the current time as the time at which the RF will be fully enabled.  

This fixes the advertising issue described in the comments under Issue #302 (although the issue itself might be about broader connectivity problems).