### PR TITLE
Alarm: Display the time until alarm, even if it is off

### DIFF
--- a/src/components/alarm/AlarmController.h
+++ b/src/components/alarm/AlarmController.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include "app_timer.h"
 #include "components/datetime/DateTimeController.h"
+#include <chrono>
 
 namespace Pinetime {
   namespace System {
@@ -32,6 +33,7 @@ namespace Pinetime {
 
       void Init(System::SystemTask* systemTask);
       void SetAlarmTime(uint8_t alarmHr, uint8_t alarmMin);
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> TimePoint();
       void ScheduleAlarm();
       void DisableAlarm();
       void SetOffAlarmNow();

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -209,19 +209,15 @@ void Alarm::ShowInfo() {
   txtMessage = lv_label_create(btnMessage, nullptr);
   lv_obj_set_style_local_bg_color(btnMessage, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_NAVY);
 
-  if (alarmController.State() == AlarmController::AlarmState::Set) {
-    auto timeToAlarm = alarmController.SecondsToAlarm();
+  auto timeToAlarm = alarmController.SecondsToAlarm();
 
-    auto daysToAlarm = timeToAlarm / 86400;
-    auto hrsToAlarm = (timeToAlarm % 86400) / 3600;
-    auto minToAlarm = (timeToAlarm % 3600) / 60;
-    auto secToAlarm = timeToAlarm % 60;
+  auto daysToAlarm = timeToAlarm / 86400;
+  auto hrsToAlarm = (timeToAlarm % 86400) / 3600;
+  auto minToAlarm = (timeToAlarm % 3600) / 60;
+  auto secToAlarm = timeToAlarm % 60;
 
-    lv_label_set_text_fmt(
-      txtMessage, "Time to\nalarm:\n%2d Days\n%2d Hours\n%2d Minutes\n%2d Seconds", daysToAlarm, hrsToAlarm, minToAlarm, secToAlarm);
-  } else {
-    lv_label_set_text(txtMessage, "Alarm\nis not\nset.");
-  }
+  lv_label_set_text_fmt(
+    txtMessage, "Time to\nalarm:\n%2d Days\n%2d Hours\n%2d Minutes\n%2d Seconds", daysToAlarm, hrsToAlarm, minToAlarm, secToAlarm);
 }
 
 void Alarm::SetRecurButtonState() {


### PR DESCRIPTION
Previously, if the alarm was turned off, when you pressed the information button, a message was displayed that the alarm was not set. The amount of time until the alarm is now displayed as well as if it is on.
What for? Allows you to save two clicks on a button if you just need to see how much time is left before the alarm

## Before
![Before](https://user-images.githubusercontent.com/50026114/135069083-08c9b18f-d2e5-4e96-8c90-a053869bd0b9.jpg)

## After
![After](https://user-images.githubusercontent.com/50026114/135069753-d407035e-2dbc-4487-b013-10db0eba6fb9.jpg)