### PR TITLE
Alarm: Close the popup with information about the time until alarm with the back button

### DIFF
--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -174,6 +174,17 @@ void Alarm::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
   }
 }
 
+bool Alarm::OnButtonPushed() {
+  if (txtMessage != nullptr && btnMessage != nullptr) {
+    lv_obj_del(txtMessage);
+    lv_obj_del(btnMessage);
+    txtMessage = nullptr;
+    btnMessage = nullptr;
+    return true;
+  }
+  return false;
+}
+
 void Alarm::UpdateAlarmTime() {
   lv_label_set_text_fmt(time, "%02d:%02d", alarmHours, alarmMinutes);
   alarmController.SetAlarmTime(alarmHours, alarmMinutes);

--- a/src/displayapp/screens/Alarm.h
+++ b/src/displayapp/screens/Alarm.h
@@ -31,6 +31,7 @@ namespace Pinetime {
         ~Alarm() override;
         void SetAlerting();
         void OnButtonEvent(lv_obj_t* obj, lv_event_t event);
+        bool OnButtonPushed() override;
 
       private:
         bool running;


### PR DESCRIPTION
Previously, pressing the back button would close the alarm app anyway. Now if you press on it and the popup with information is open, it will first close and the second press will close the application